### PR TITLE
ResyncTrigger fixes

### DIFF
--- a/CS2MultiplayerMod/Core/Protocol/Framing/MessageCodec.cs
+++ b/CS2MultiplayerMod/Core/Protocol/Framing/MessageCodec.cs
@@ -42,7 +42,8 @@ namespace CS2MultiplayerMod.Core.Protocol
             codec.Register(MessageType.BlobChunk, () => new BlobChunkMessage(),
                 ProtocolConstants.BlobChunkBytes + 1024);
             codec.Register(MessageType.StateEdit, () => new StateEditMessage(), 128 * 1024);
-            codec.Register(MessageType.ResyncRequest, () => new ResyncRequestMessage(), 64);
+            // Sized for the player id plus a capped, UTF-8 encoded reason string.
+            codec.Register(MessageType.ResyncRequest, () => new ResyncRequestMessage(), 1024);
             codec.Register(MessageType.WorldSyncControl, () => new WorldSyncControlMessage(), 64);
             codec.Register(MessageType.DisconnectNotice, () => new DisconnectNoticeMessage(), 1024);
             return codec;

--- a/CS2MultiplayerMod/Core/Protocol/Messages/Sync/ResyncRequestMessage.cs
+++ b/CS2MultiplayerMod/Core/Protocol/Messages/Sync/ResyncRequestMessage.cs
@@ -1,25 +1,41 @@
 namespace CS2MultiplayerMod.Core.Protocol.Messages
 {
     /// <summary>
-    /// Client -> host: "stream current world now." Sent when player runs <c>/sync</c>
-    /// due to suspected city drift. Host saves and streams live world - periodic
-    /// resync but on demand.
+    /// Client -> host: "stream current world now." Sent when the player runs <c>/sync</c>
+    /// due to suspected city drift, and when the client's own sync pipeline settles on a
+    /// world reload. Host saves and streams live world - periodic resync but on demand.
+    ///
+    /// <see cref="Reason"/> carries WHY, so the host's log distinguishes a player pressing
+    /// the button from a client that could not apply an edit. It is untrusted display text:
+    /// the reader sanitizes it, and nothing branches on its content.
     /// </summary>
     public sealed class ResyncRequestMessage : INetMessage
     {
         public int OriginPlayerId;
 
+        /// <summary>Short human-readable cause, for logs only. Never null after a read.</summary>
+        public string Reason;
+
         public ResyncRequestMessage() { }
 
-        public ResyncRequestMessage(int originPlayerId)
+        public ResyncRequestMessage(int originPlayerId, string reason = null)
         {
             OriginPlayerId = originPlayerId;
+            Reason = reason;
         }
 
         public MessageType Type => MessageType.ResyncRequest;
 
-        public void Write(NetworkWriter writer) => writer.WriteInt(OriginPlayerId);
+        public void Write(NetworkWriter writer)
+        {
+            writer.WriteInt(OriginPlayerId);
+            writer.WriteString(WireGuard.SanitizeText(Reason, WireGuard.MaxResyncReasonLength));
+        }
 
-        public void Read(NetworkReader reader) => OriginPlayerId = reader.ReadInt();
+        public void Read(NetworkReader reader)
+        {
+            OriginPlayerId = reader.ReadInt();
+            Reason = WireGuard.SanitizeText(reader.ReadString(), WireGuard.MaxResyncReasonLength);
+        }
     }
 }

--- a/CS2MultiplayerMod/Core/Protocol/ProtocolConstants.cs
+++ b/CS2MultiplayerMod/Core/Protocol/ProtocolConstants.cs
@@ -4,7 +4,11 @@ namespace CS2MultiplayerMod.Core.Protocol
     {
         /// <summary>
         /// Wire-format version. Bump when message layout changes to refuse handshake on mismatch.
-        /// Current v49 adds city-state channel 22: host-authoritative workplace state for every
+        /// Current v50 adds a reason string to ResyncRequest. It is log text only - nothing
+        /// branches on it - but without it the host's log cannot tell a player pressing the sync
+        /// button apart from a client whose pipeline gave up on an edit, which is the single most
+        /// useful distinction when reading a session that kept reloading its world.
+        /// v49 adds city-state channel 22: host-authoritative workplace state for every
         /// commercial, industrial and office building. Each page entry is about the building, not
         /// the business, so the host can say "nobody rents this one" - the one statement a client
         /// cannot derive for itself. Occupied entries carry the tenant's archetype, the whole
@@ -115,7 +119,7 @@ namespace CS2MultiplayerMod.Core.Protocol
         /// islands) reattach on the receiver.
         /// See <see cref="Messages.HandshakeRequest"/> and version notes in doc/internals.
         /// </summary>
-        public const int ProtocolVersion = 49;
+        public const int ProtocolVersion = 50;
 
         /// <summary>
         /// Hard cap on a single payload, guarding against corrupt length prefixes.

--- a/CS2MultiplayerMod/Core/Protocol/Wire/WireGuard.cs
+++ b/CS2MultiplayerMod/Core/Protocol/Wire/WireGuard.cs
@@ -19,6 +19,9 @@ namespace CS2MultiplayerMod.Core.Protocol
         /// <summary>Cap for one chat line.</summary>
         public const int MaxChatLength = 500;
 
+        /// <summary>Cap for the reason a peer gives for asking to be re-synced (log text only).</summary>
+        public const int MaxResyncReasonLength = 120;
+
         /// <summary>Cap for node/waypoint style repeat counts in commands.</summary>
         public const int MaxItemCount = 4096;
 

--- a/CS2MultiplayerMod/Core/Session/MultiplayerSession/Messaging.cs
+++ b/CS2MultiplayerMod/Core/Session/MultiplayerSession/Messaging.cs
@@ -132,45 +132,64 @@ namespace CS2MultiplayerMod.Core.Session
         /// current world; on the host it refreshes every client. The actual save+stream
         /// is done by the observer (the game layer owns savegames).
         /// </summary>
-        public void RequestWorldSync()
+        public void RequestWorldSync(string reason = null)
         {
             if (Status != SessionStatus.Connected) return;
+            reason = WireGuard.SanitizeText(reason, WireGuard.MaxResyncReasonLength);
+            if (reason.Length == 0) reason = ManualSyncReason;
             if (_worldSyncSuspended)
             {
-                _log.Info("World sync request coalesced into active epoch " + _worldSyncEpoch + ".");
+                _log.Info("World sync request coalesced into active epoch " + _worldSyncEpoch +
+                          " (" + reason + ").");
                 return;
             }
 
             if (Role == SessionRole.Client)
             {
-                SendTo(ConnectionId.Server, new ResyncRequestMessage(LocalPlayerId));
-                _log.Info("World sync request sent to host.");
+                SendTo(ConnectionId.Server, new ResyncRequestMessage(LocalPlayerId, reason));
+                _log.Info("World sync request sent to host (" + reason + ").");
                 NotifyChat(null, "World sync requested - the host will stream you its city.");
             }
             else if (Role == SessionRole.Host)
             {
-                _log.Info("Host requested world sync for all clients.");
+                _log.Info("Host requested world sync for all clients (" + reason + ").");
                 NotifyResyncRequested(LocalPlayerId, ConnectionId.None);
                 NotifyChat(null, "World sync started - streaming the city to all players.");
             }
         }
 
+        /// <summary>What a request carries when the player asked for it themselves.</summary>
+        internal const string ManualSyncReason = "requested by the player";
+
         private void HandleResyncRequest(ConnectionId from, Peer peer, long nowUnixMs)
         {
+            HandleResyncRequest(from, peer, nowUnixMs, ManualSyncReason);
+        }
+
+        private void HandleResyncRequest(ConnectionId from, Peer peer, long nowUnixMs, string reason)
+        {
             if (Role != SessionRole.Host) return;
+
+            reason = WireGuard.SanitizeText(reason, WireGuard.MaxResyncReasonLength);
+            if (reason.Length == 0) reason = ManualSyncReason;
 
             // Rate limit: a misbehaving client spamming /sync would otherwise keep the
             // host in a permanent save+stream loop. (Per-peer budgets run on top.)
             if (nowUnixMs - _lastResyncAcceptedUnixMs < ResyncRequestCooldownMs)
             {
                 _log.Warn("Ignoring /sync from " + (peer != null ? peer.ToString() : from.ToString()) +
-                          ": a world sync ran moments ago.");
+                          " (" + reason + "): a world sync ran moments ago.");
                 return;
             }
             _lastResyncAcceptedUnixMs = nowUnixMs;
 
             // The requester's identity comes from OUR peer table, never from the wire.
             string name = peer != null && peer.Name != null ? peer.Name : from.ToString();
+
+            // Why the other machine gave up belongs in THIS log too. Without it the host's log
+            // reads "someone asked for a sync" for both a player pressing the button and a client
+            // pipeline that could not apply an edit - the two cases that need telling apart most.
+            _log.Info("World sync requested by " + name + ": " + reason + ".");
 
             // Tell everyone the world is about to snap, then let the game layer stream it.
             string notice = name + " requested a world sync.";

--- a/CS2MultiplayerMod/Core/Session/MultiplayerSession/Transport.cs
+++ b/CS2MultiplayerMod/Core/Session/MultiplayerSession/Transport.cs
@@ -236,7 +236,8 @@ namespace CS2MultiplayerMod.Core.Session
                     HandleBlobChunk(connection, peer, (BlobChunkMessage)message, nowUnixMs);
                     break;
                 case MessageType.ResyncRequest:
-                    HandleResyncRequest(connection, peer, nowUnixMs);
+                    HandleResyncRequest(connection, peer, nowUnixMs,
+                        ((ResyncRequestMessage)message).Reason);
                     break;
                 case MessageType.WorldSyncControl:
                     HandleWorldSyncControl(connection, peer, (WorldSyncControlMessage)message);

--- a/CS2MultiplayerMod/Game/Diagnostics/ResyncArbiter.cs
+++ b/CS2MultiplayerMod/Game/Diagnostics/ResyncArbiter.cs
@@ -1,0 +1,284 @@
+using System.Collections.Generic;
+
+namespace CS2MultiplayerMod.Game.Diagnostics
+{
+    /// <summary>What the arbiter decided about a submitted <see cref="ResyncReport"/>.</summary>
+    public enum ResyncVerdict
+    {
+        /// <summary>
+        /// Not settled yet. A caller that can keep its work must KEEP it and retry: the mutating
+        /// net feeders are frozen for the length of the hold, so the retry runs against a world
+        /// that is no longer moving underneath it.
+        ///
+        /// Held is not "dismissed". Unless something calls <see cref="ResyncArbiter.Withdraw"/> to
+        /// say the fault cleared, the report settles by itself when its hold elapses - so a real
+        /// divergence still gets repaired, it just gets one honest chance not to be one first.
+        /// </summary>
+        Held = 0,
+
+        /// <summary>Settled: the evidence stands. The world will be reloaded.</summary>
+        Settled,
+
+        /// <summary>
+        /// Settled by someone else already - a reload is in flight. The caller drops its work; the
+        /// incoming snapshot supersedes it either way.
+        /// </summary>
+        AlreadyRecovering,
+    }
+
+    /// <summary>
+    /// The gate every automatic world reload passes through.
+    ///
+    /// A resync costs both players a save, a tens-of-megabyte transfer and a full world load, and
+    /// it does not fix the edit that triggered it - that edit is simply gone afterwards. So it is
+    /// worth being sure. The field logs behind this class show two shapes of wrong answer:
+    ///
+    ///  * A placement was rejected because a road it anchors to was "missing", while this machine's
+    ///    own delete feeder had bulldozed that road during the ten seconds the placement spent
+    ///    waiting. The divergence was manufactured by the wait, not observed before it.
+    ///  * A commit was quarantined because 311 entities had not left their temporary state inside a
+    ///    fixed three-second window - a window tuned against batches a sixth of that size.
+    ///
+    /// Both are timeouts dressed as evidence. So a claim about the CITY (a named thing is absent,
+    /// an identity contradicts) is allowed to settle on sight or on its second sighting, while a
+    /// claim about this machine's PIPELINE has to survive a hold first. During the hold the feeders
+    /// that can only destroy what a pending edit is waiting for stand down, and the subsystem that
+    /// raised the report gets to retry against a world that is standing still. If it succeeds it
+    /// withdraws the report; if nothing withdraws it, the hold elapses and the reload happens.
+    ///
+    /// Every outcome - held, withdrawn, settled - is written at the production log level with the
+    /// full report, so the log says why the world was reloaded, or why it nearly was, even when no
+    /// diagnostic switch was ever turned on.
+    /// </summary>
+    public static class ResyncArbiter
+    {
+        /// <summary>
+        /// How long a report is held before it settles on its own. Long enough for a large native
+        /// drain to finish and for a deferred operation to see another full retry window against a
+        /// frozen world; short enough that a genuinely diverged city is not played on.
+        /// </summary>
+        private const long HoldWindowMs = 12000;
+
+        /// <summary>Bound on distinct held reports, so a flapping subsystem cannot grow this.</summary>
+        private const int MaxHeld = 32;
+
+        private sealed class Held
+        {
+            public ResyncReport Report;
+            public long HoldUntilMs;
+        }
+
+        private static readonly object Gate = new object();
+        private static readonly Dictionary<string, Held> Pending = new Dictionary<string, Held>();
+
+        /// <summary>The subsystem whose held reports freeze the net-mutation feeders.</summary>
+        private const string NetSubsystem = "net";
+
+        /// <summary>
+        /// True while a NET report is being corroborated. The feeders that can only destroy a
+        /// pending road operation's target - bulldoze, road replacement - stand down while this is
+        /// set, so the retry that decides the verdict is not racing this machine's own mutations.
+        ///
+        /// Only net reports count. A held route or growable report says nothing about whether a
+        /// road is about to be removed, and freezing bulldozing for it would be a pause the player
+        /// feels for no reason. Bounded by the hold window either way.
+        /// </summary>
+        public static bool NetMutationFrozen(long nowMs)
+        {
+            lock (Gate)
+            {
+                foreach (KeyValuePair<string, Held> entry in Pending)
+                    if (nowMs < entry.Value.HoldUntilMs &&
+                        entry.Value.Report.Subsystem == NetSubsystem) return true;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Weigh one report. Returns what the caller must do; never reloads anything itself.
+        /// <paramref name="recovering"/> is true when a world reload is already under way.
+        /// </summary>
+        public static ResyncVerdict Submit(ResyncReport report, long nowMs, bool recovering)
+        {
+            if (report == null) return ResyncVerdict.Held;
+
+            if (recovering)
+            {
+                SyncLog.Prod("World sync: " + report.Reason +
+                             " while a world sync is already running; folded into it (" +
+                             report.Subsystem + "/" + report.Subject + ").");
+                return ResyncVerdict.AlreadyRecovering;
+            }
+
+            bool settle;
+            int observations;
+            long heldForMs = 0;
+            lock (Gate)
+            {
+                string key = KeyOf(report.Subsystem, report.Reason, report.Subject);
+                Held held;
+                if (Pending.TryGetValue(key, out held))
+                {
+                    held.Report.Observations++;
+                    observations = held.Report.Observations;
+                    heldForMs = nowMs - held.Report.FirstSeenMs;
+                    // Seen again. A claim about the world is now corroborated. A claim about this
+                    // machine's own pipeline is not: failing again one frame later says nothing the
+                    // first failure did not, and the hold is what gives the retry a quiet world.
+                    settle = SettlesOnRepeat(report.Evidence) || nowMs >= held.HoldUntilMs;
+                    if (settle) Pending.Remove(key);
+                }
+                else
+                {
+                    report.FirstSeenMs = nowMs;
+                    report.Observations = 1;
+                    observations = 1;
+                    settle = SettlesImmediately(report.Evidence);
+                    if (!settle)
+                    {
+                        if (Pending.Count >= MaxHeld) Evict();
+                        Pending[key] = new Held
+                        {
+                            Report = report,
+                            HoldUntilMs = nowMs + HoldWindowMs,
+                        };
+                    }
+                }
+            }
+
+            if (settle)
+            {
+                // States the VERDICT, not the action. Whether the reload actually runs is the
+                // service's call - it still has a cooldown - and it reports that itself.
+                SyncLog.ProdReport(
+                    "World sync: this city and the host's have diverged and cannot be reconciled " +
+                    "locally. Reason: " + report.Reason + ".",
+                    Decorate(report, observations, heldForMs, settled: true));
+                return ResyncVerdict.Settled;
+            }
+
+            SyncLog.ProdReport(
+                "World sync: holding off on a world reload for up to " + (HoldWindowMs / 1000) +
+                " s while this is confirmed. Reason: " + report.Reason + ".",
+                Decorate(report, observations, heldForMs, settled: false));
+            return ResyncVerdict.Held;
+        }
+
+        /// <summary>
+        /// Tell the arbiter a held fault has cleared - the operation resolved, the graph drained.
+        /// Withdrawing is the whole point of holding: it is a world reload that did not have to
+        /// happen, and it is written to the production log in the same shape as one that did.
+        ///
+        /// This is the ONLY way a held report goes away without a reload. A subsystem that drops
+        /// its work instead of retrying simply never calls it, and its report matures on schedule.
+        /// </summary>
+        public static void Withdraw(string subsystem, string reason, string subject, long nowMs,
+            string outcome)
+        {
+            Held held;
+            lock (Gate)
+            {
+                string key = KeyOf(subsystem, reason, subject);
+                if (!Pending.TryGetValue(key, out held)) return;
+                Pending.Remove(key);
+            }
+
+            List<string> lines = held.Report.Lines();
+            lines.Add("held for: " + (nowMs - held.Report.FirstSeenMs) + " ms");
+            lines.Add("outcome: " + (outcome ?? "the fault cleared on its own"));
+            SyncLog.ProdReport(
+                "World sync: not needed after all - " + held.Report.Reason +
+                " resolved without reloading the world.", lines);
+        }
+
+        /// <summary>
+        /// Reports whose hold has elapsed with nothing withdrawing them. They are settled: the
+        /// caller reloads the world for the first one and folds the rest into it.
+        /// </summary>
+        public static List<ResyncReport> TakeMatured(long nowMs)
+        {
+            List<Held> matured = null;
+            lock (Gate)
+            {
+                if (Pending.Count == 0) return null;
+                List<string> drop = null;
+                foreach (KeyValuePair<string, Held> entry in Pending)
+                {
+                    if (nowMs < entry.Value.HoldUntilMs) continue;
+                    (drop ?? (drop = new List<string>())).Add(entry.Key);
+                    (matured ?? (matured = new List<Held>())).Add(entry.Value);
+                }
+                if (drop != null)
+                    for (int i = 0; i < drop.Count; i++) Pending.Remove(drop[i]);
+            }
+
+            if (matured == null) return null;
+            var reports = new List<ResyncReport>(matured.Count);
+            for (int i = 0; i < matured.Count; i++)
+            {
+                ResyncReport report = matured[i].Report;
+                List<string> lines = report.Lines();
+                lines.Add("observed: " + report.Observations +
+                          (report.Observations == 1 ? " time" : " times"));
+                lines.Add("held for: " + (nowMs - report.FirstSeenMs) +
+                          " ms with the net feeders standing down");
+                lines.Add("verdict: settled - nothing repaired it in that time");
+                SyncLog.ProdReport(
+                    "World sync: the hold expired and " + report.Reason +
+                    " is still unresolved, so this city has to be replaced by the host's.", lines);
+                reports.Add(report);
+            }
+            return reports;
+        }
+
+        /// <summary>Forget everything (a world reload, a session end): the evidence no longer applies.</summary>
+        public static void Reset()
+        {
+            lock (Gate) Pending.Clear();
+        }
+
+        private static string KeyOf(string subsystem, string reason, string subject) =>
+            (subsystem ?? "sync") + "|" + reason + "|" + (subject ?? reason);
+
+        private static List<string> Decorate(ResyncReport report, int observations, long heldForMs,
+            bool settled)
+        {
+            List<string> lines = report.Lines();
+            lines.Add("observed: " + observations + (observations == 1 ? " time" : " times") +
+                      (heldForMs > 0 ? ", first seen " + heldForMs + " ms ago" : string.Empty));
+            lines.Add(settled
+                ? "verdict: settled - this is a real divergence and cannot be repaired locally"
+                : "verdict: not settled yet - the net feeders stand down and the edit is retried; " +
+                  "the world is reloaded in " + (HoldWindowMs / 1000) + " s unless it resolves");
+            return lines;
+        }
+
+        /// <summary>
+        /// A contradiction or a lost command is not a wait-and-see: nothing local will supply the
+        /// missing commands, and a contradiction is already a statement about two worlds.
+        /// </summary>
+        private static bool SettlesImmediately(ResyncEvidence evidence) =>
+            evidence == ResyncEvidence.Contradiction || evidence == ResyncEvidence.StreamLoss;
+
+        /// <summary>A missing target seen twice is a missing target. A timeout seen twice is not.</summary>
+        private static bool SettlesOnRepeat(ResyncEvidence evidence) =>
+            evidence != ResyncEvidence.Timeout;
+
+        /// <summary>
+        /// Drop the report closest to maturing. It is the one that has already had its chance, and
+        /// dropping it costs at most a delayed reload - the fault will be raised again.
+        /// </summary>
+        private static void Evict()
+        {
+            string oldest = null;
+            long soonest = long.MaxValue;
+            foreach (KeyValuePair<string, Held> entry in Pending)
+                if (entry.Value.HoldUntilMs < soonest)
+                {
+                    soonest = entry.Value.HoldUntilMs;
+                    oldest = entry.Key;
+                }
+            if (oldest != null) Pending.Remove(oldest);
+        }
+    }
+}

--- a/CS2MultiplayerMod/Game/Diagnostics/ResyncReport.cs
+++ b/CS2MultiplayerMod/Game/Diagnostics/ResyncReport.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace CS2MultiplayerMod.Game.Diagnostics
+{
+    /// <summary>
+    /// What a resync request is actually claiming about the world.
+    ///
+    /// The distinction matters because only two of these are statements about the CITY. The other
+    /// two are statements about this machine's pipeline, and a pipeline that fell behind is not a
+    /// reason to throw away tens of megabytes of world and freeze both players for half a minute.
+    /// Field logs show that difference costing real sessions: an operation was rejected for a
+    /// "missing" road that the mod's own delete feeder had removed while the placement waited.
+    /// </summary>
+    public enum ResyncEvidence
+    {
+        /// <summary>
+        /// A deadline, retry budget or drain window expired. Says nothing about the world - the
+        /// pipeline may simply have been blocked by something unrelated for the whole window.
+        /// Always needs corroboration.
+        /// </summary>
+        Timeout = 0,
+
+        /// <summary>
+        /// Something the source named is not present locally and the pipeline looked for it.
+        /// Usually a real divergence, but the search runs against a world other feeders are still
+        /// mutating, so it also needs one corroboration under a quiesced pipeline.
+        /// </summary>
+        MissingTarget,
+
+        /// <summary>
+        /// The local world contradicts the source's description in a way no amount of waiting can
+        /// repair - two source entities collapsed onto one local entity, a duplicate identity, a
+        /// graph that cannot be committed without dereferencing a stale original. Settles at once.
+        /// </summary>
+        Contradiction,
+
+        /// <summary>
+        /// Part of the command stream was lost, shed or refused before it could be applied, so
+        /// this machine can no longer derive the source's state from what it received. Settles at
+        /// once: nothing local will ever supply the missing commands.
+        /// </summary>
+        StreamLoss,
+    }
+
+    /// <summary>
+    /// The evidence behind one resync request.
+    ///
+    /// Historically every caller passed a bare phrase ("native net target did not resolve") and the
+    /// world reloaded. That is enough to grep for and not enough to fix anything: the log never
+    /// said which operation, which endpoint, what was actually standing there instead, how long the
+    /// pipeline had been blocked, or whether anything cheaper had been tried. A report carries all
+    /// of that, is written at the production log level whether or not the reload follows, and is
+    /// what <see cref="ResyncArbiter"/> settles before any world is thrown away.
+    ///
+    /// Build one with <see cref="Create"/> and chain <see cref="Fact"/> calls; every setter returns
+    /// the report so a call site stays one statement.
+    /// </summary>
+    public sealed class ResyncReport
+    {
+        /// <summary>Facts are bounded: a report is a log line, not a heap dump.</summary>
+        private const int MaxFacts = 24;
+        private const int MaxFactChars = 220;
+
+        private readonly List<string> _facts = new List<string>();
+
+        private ResyncReport(string reason, string subsystem, ResyncEvidence evidence)
+        {
+            Reason = string.IsNullOrEmpty(reason) ? "sync pipeline recovery" : reason;
+            Subsystem = string.IsNullOrEmpty(subsystem) ? "sync" : subsystem;
+            Evidence = evidence;
+            Subject = Reason;
+        }
+
+        /// <summary>The short phrase this request has always carried. Still the grep key.</summary>
+        public string Reason { get; private set; }
+
+        /// <summary>Which sync domain raised it: net, object, route, growable, area, stream.</summary>
+        public string Subsystem { get; private set; }
+
+        public ResyncEvidence Evidence { get; private set; }
+
+        /// <summary>
+        /// What the request is about, stable across repeats - typically the operation identity.
+        /// Two submissions with the same subject and reason are the SAME fault observed twice,
+        /// which is what lets a held report settle; two different subjects are two faults.
+        /// </summary>
+        public string Subject { get; private set; }
+
+        /// <summary>
+        /// What the pipeline already tried before asking for a reload, in the caller's own words
+        /// ("retried for 10 s", "replayed 3x"). Printed as its own line: a reader's first question
+        /// about any automatic world reload is whether anything cheaper was attempted.
+        /// </summary>
+        public string Attempted { get; private set; }
+
+        /// <summary>Set by the arbiter when the report is first submitted.</summary>
+        public long FirstSeenMs { get; internal set; }
+
+        /// <summary>How many times this exact fault has been submitted, including the first.</summary>
+        public int Observations { get; internal set; }
+
+        public static ResyncReport Create(string reason, string subsystem, ResyncEvidence evidence)
+        {
+            return new ResyncReport(reason, subsystem, evidence);
+        }
+
+        /// <summary>A bare legacy request: unclassified, and therefore never settled on sight.</summary>
+        public static ResyncReport FromReason(string reason)
+        {
+            return new ResyncReport(reason, "sync", ResyncEvidence.Timeout);
+        }
+
+        public ResyncReport About(string subject)
+        {
+            if (!string.IsNullOrEmpty(subject)) Subject = subject;
+            return this;
+        }
+
+        public ResyncReport Tried(string attempted)
+        {
+            Attempted = attempted;
+            return this;
+        }
+
+        /// <summary>Record one named observation. Silently ignored past the cap.</summary>
+        public ResyncReport Fact(string name, string value)
+        {
+            if (string.IsNullOrEmpty(name) || _facts.Count >= MaxFacts) return this;
+            string text = name + ": " + (value ?? "(none)");
+            if (text.Length > MaxFactChars) text = text.Substring(0, MaxFactChars) + "…";
+            _facts.Add(text);
+            return this;
+        }
+
+        public ResyncReport Fact(string name, long value)
+        {
+            return Fact(name, value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+
+        public ResyncReport Fact(string name, bool value) => Fact(name, value ? "yes" : "no");
+
+        /// <summary>
+        /// The report as the lines the production log prints under its headline. Written in
+        /// sentences, because the reader is usually a player pasting a log into a bug report.
+        /// </summary>
+        public List<string> Lines()
+        {
+            var lines = new List<string>(_facts.Count + 4);
+            lines.Add("what happened: " + Reason);
+            lines.Add("where: " + Subsystem + " sync, " + Subject);
+            lines.Add("evidence: " + Describe(Evidence));
+            if (!string.IsNullOrEmpty(Attempted)) lines.Add("already tried: " + Attempted);
+            lines.AddRange(_facts);
+            return lines;
+        }
+
+        /// <summary>One-line form for the flight recorder and the chat/system feed.</summary>
+        public string Summary()
+        {
+            var text = new StringBuilder(Reason);
+            text.Append(" [").Append(Subsystem).Append('/').Append(Subject).Append(']');
+            for (int i = 0; i < _facts.Count; i++) text.Append(' ').Append(_facts[i]);
+            return text.ToString();
+        }
+
+        private static string Describe(ResyncEvidence evidence)
+        {
+            switch (evidence)
+            {
+                case ResyncEvidence.MissingTarget:
+                    return "something the other player's edit named is not present here";
+                case ResyncEvidence.Contradiction:
+                    return "this world contradicts the edit and no amount of waiting repairs it";
+                case ResyncEvidence.StreamLoss:
+                    return "part of the command stream was lost before it could be applied";
+                default:
+                    return "a deadline expired - this may be a local stall rather than a divergence";
+            }
+        }
+    }
+}

--- a/CS2MultiplayerMod/Game/Diagnostics/SyncLog.cs
+++ b/CS2MultiplayerMod/Game/Diagnostics/SyncLog.cs
@@ -12,6 +12,21 @@ namespace CS2MultiplayerMod.Game.Diagnostics
         /// <summary>Anything without a more specific home. Follows the general verbose switch.</summary>
         General = 0,
 
+        /// <summary>
+        /// The production level: always written, never gated by a setting, and deliberately
+        /// unprefixed.
+        ///
+        /// It exists for the handful of lines that have to be in every player's log because they
+        /// are what a bug report is read for - why the world was reloaded, what the pipeline was
+        /// holding when it decided, what it tried first. A player never turns these on, so they
+        /// cannot be missing from the one log that matters, and a reader who does not know the
+        /// mod's topic prefixes still reads them as ordinary sentences.
+        ///
+        /// It is not a dumping ground: anything that would repeat per frame, per entity or per
+        /// command belongs to a topic switch or the flight recorder instead.
+        /// </summary>
+        Prod,
+
         /// <summary>Frame times and the mod's own main-thread cost, including the per-zone split.</summary>
         Performance,
 
@@ -36,14 +51,17 @@ namespace CS2MultiplayerMod.Game.Diagnostics
     /// building the string. And a line always says which topic it belongs to, so a log with
     /// several topics on is still readable and greppable.
     ///
-    /// Faults are never routed here. A warning or an error is not a diagnostic a player chooses
-    /// to receive; those keep going straight to the game log and the flight recorder.
+    /// A fault is never a topic. A warning or an error is not a diagnostic a player chooses to
+    /// receive, so it is never gated by a switch: it goes out through the production level
+    /// (<see cref="Prod"/>, <see cref="ProdWarn"/>, <see cref="ProdError"/>, <see cref="ProdReport"/>),
+    /// which writes to the game log and the flight recorder unconditionally and without a prefix.
     /// </summary>
     public static class SyncLog
     {
         private static readonly string[] Prefixes =
         {
             "[MP] ",
+            "",             // Prod: deliberately unprefixed.
             "[MP][perf] ",
             "[MP][residential] ",
             "[MP][commercial] ",
@@ -57,6 +75,9 @@ namespace CS2MultiplayerMod.Game.Diagnostics
         /// </summary>
         public static bool IsEnabled(LogTopic topic)
         {
+            // Asked before the setting exists too: a fault during load still has to be reported,
+            // and the production level is the level that is never allowed to be silent.
+            if (topic == LogTopic.Prod) return true;
             Setting setting = Mod.Setting;
             if (setting == null) return false;
             switch (topic)
@@ -94,6 +115,61 @@ namespace CS2MultiplayerMod.Game.Diagnostics
         {
             if (IsEnabled(topic)) Mod.log.Info(Prefix(topic) + message);
             FlightRecorder.Note(message);
+        }
+
+        /// <summary>
+        /// Write one production line: always emitted, no prefix, and always mirrored to the flight
+        /// recorder so the structured log carries the same statement as the game log.
+        /// </summary>
+        public static void Prod(string message)
+        {
+            if (message == null) return;
+            Mod.log.Info(message);
+            FlightRecorder.Note(message);
+        }
+
+        /// <summary>A production line the player is meant to act on (or explain in a report).</summary>
+        public static void ProdWarn(string message)
+        {
+            if (message == null) return;
+            Mod.log.Warn(message);
+            FlightRecorder.Note(message);
+        }
+
+        /// <summary>A production line for a fault the mod could not work around.</summary>
+        public static void ProdError(string message)
+        {
+            if (message == null) return;
+            Mod.log.Error(message);
+            FlightRecorder.Note(message);
+        }
+
+        /// <summary>
+        /// Write a multi-line production report. Each line goes out on its own so the game log
+        /// stays one-statement-per-line and greppable; the flight recorder takes the whole report
+        /// as a single compact event, because there it is one fact, not many.
+        /// </summary>
+        public static void ProdReport(string headline, System.Collections.Generic.IList<string> lines)
+        {
+            if (headline != null) Mod.log.Info(headline);
+            if (lines != null)
+                for (int i = 0; i < lines.Count; i++)
+                    if (lines[i] != null) Mod.log.Info("    " + lines[i]);
+            FlightRecorder.Note(FlattenReport(headline, lines));
+        }
+
+        private static string FlattenReport(string headline,
+            System.Collections.Generic.IList<string> lines)
+        {
+            var flat = new System.Text.StringBuilder(headline ?? string.Empty);
+            if (lines != null)
+                for (int i = 0; i < lines.Count; i++)
+                {
+                    if (lines[i] == null) continue;
+                    if (flat.Length > 0) flat.Append(" | ");
+                    flat.Append(lines[i]);
+                }
+            return flat.ToString();
         }
 
         private static LogTopic TopicFor(SyncZone zone)

--- a/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
@@ -53,6 +53,7 @@ namespace CS2MultiplayerMod.Game
                 SyncInbox.TryTakeResyncRequest(out queuedReport))
                 RequestAutomaticWorldRecovery(queuedReport);
             PumpMaturedResyncReports();
+            PumpMapReRequest();
             PumpWorldPhase();
             MaintainWorldSyncBarrier();
             PumpClientWorldSyncQuiescence();
@@ -277,6 +278,7 @@ namespace CS2MultiplayerMod.Game
         {
             _disconnectConfirmationRequested = false;
             _settledReport = null;
+            _mapReRequestPending = false;
             Diagnostics.ResyncArbiter.Reset();
             ResetWorldSyncState(restoreSpeed: false); // the world is going away with the process
             _session.StopWithNotice("The host closed the game, so this session has ended.");

--- a/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
@@ -280,6 +280,7 @@ namespace CS2MultiplayerMod.Game
             _settledReport = null;
             _mapReRequestPending = false;
             Diagnostics.ResyncArbiter.Reset();
+            Sync.Infrastructure.RealizeGate.Reset();
             ResetWorldSyncState(restoreSpeed: false); // the world is going away with the process
             _session.StopWithNotice("The host closed the game, so this session has ended.");
             SetPhase(ClientWorldPhase.None);

--- a/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/Lifecycle/Phase.cs
@@ -48,10 +48,11 @@ namespace CS2MultiplayerMod.Game
             PumpClientWorldSave();
             PumpDeferredReceivedMap();
             RefreshPendingJoinsJson();
-            string recoveryReason;
+            Diagnostics.ResyncReport queuedReport;
             if (_session.Status == SessionStatus.Connected &&
-                SyncInbox.TryTakeResyncRequest(out recoveryReason))
-                RequestAutomaticWorldRecovery(recoveryReason);
+                SyncInbox.TryTakeResyncRequest(out queuedReport))
+                RequestAutomaticWorldRecovery(queuedReport);
+            PumpMaturedResyncReports();
             PumpWorldPhase();
             MaintainWorldSyncBarrier();
             PumpClientWorldSyncQuiescence();
@@ -275,6 +276,8 @@ namespace CS2MultiplayerMod.Game
         public void Shutdown()
         {
             _disconnectConfirmationRequested = false;
+            _settledReport = null;
+            Diagnostics.ResyncArbiter.Reset();
             ResetWorldSyncState(restoreSpeed: false); // the world is going away with the process
             _session.StopWithNotice("The host closed the game, so this session has ended.");
             SetPhase(ClientWorldPhase.None);

--- a/CS2MultiplayerMod/Game/MultiplayerService/MultiplayerService.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/MultiplayerService.cs
@@ -209,6 +209,37 @@ namespace CS2MultiplayerMod.Game
         private Diagnostics.ResyncReport _settledReport;
 
         /// <summary>
+        /// Set when this client must re-ask the host for a world it is otherwise never going to
+        /// receive. It deliberately bypasses the resync arbiter and the in-flight guard: this is
+        /// not a claim that the two cities diverged, it is a client saying the handover broke and
+        /// it is still waiting. See the Resume-before-load case in WorldSync.
+        /// </summary>
+        private bool _mapReRequestPending;
+
+        internal void RequestMapAgainNextTick() => _mapReRequestPending = true;
+
+        /// <summary>
+        /// Ask again for a world whose handover broke, once the session has actually left the epoch
+        /// that broke. Waiting for that is why this is a pumped flag rather than a direct call: the
+        /// session coalesces any request made while it is still inside the epoch.
+        /// </summary>
+        private void PumpMapReRequest()
+        {
+            if (!_mapReRequestPending) return;
+            if (_session == null || _session.Status != SessionStatus.Connected)
+            {
+                _mapReRequestPending = false;
+                return;
+            }
+            if (_session.WorldSyncSuspended) return;
+            _mapReRequestPending = false;
+            Diagnostics.SyncLog.ProdWarn(
+                "World sync: asking the host to stream this city again - the previous handover " +
+                "resumed before the snapshot had been installed.");
+            _session.RequestWorldSync("resume arrived before the snapshot finished loading");
+        }
+
+        /// <summary>
         /// The synchronous resync gate wired into <see cref="Sync.Infrastructure.SyncInbox.Arbitrate"/>.
         /// A caller that can still hold its work puts its evidence here and acts on the verdict:
         /// only <see cref="Diagnostics.ResyncVerdict.Settled"/> reloads the world.

--- a/CS2MultiplayerMod/Game/MultiplayerService/MultiplayerService.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/MultiplayerService.cs
@@ -198,31 +198,104 @@ namespace CS2MultiplayerMod.Game
         private const long AutoRecoveryCooldownMs = 90000;
         private long _lastAutoRecoveryMs = long.MinValue;
 
+        /// <summary>True while a world reload is already under way, in either role.</summary>
+        private bool WorldRecoveryInFlight =>
+            _worldSyncBarrierActive ||
+            _phase == ClientWorldPhase.WaitingForMap ||
+            _phase == ClientWorldPhase.LoadingMap ||
+            _phase == ClientWorldPhase.WaitingForResume;
+
+        /// <summary>A settled report waiting for the service tick to act on it. Main thread only.</summary>
+        private Diagnostics.ResyncReport _settledReport;
+
+        /// <summary>
+        /// The synchronous resync gate wired into <see cref="Sync.Infrastructure.SyncInbox.Arbitrate"/>.
+        /// A caller that can still hold its work puts its evidence here and acts on the verdict:
+        /// only <see cref="Diagnostics.ResyncVerdict.Settled"/> reloads the world.
+        ///
+        /// The VERDICT is synchronous - the caller is mid-frame and has to know right now whether to
+        /// keep its work. The reload is not: it is handed to the service tick, where world recovery
+        /// has always been started from, rather than being kicked off from inside a ToolUpdate.
+        /// </summary>
+        public Diagnostics.ResyncVerdict SettleResyncReport(Diagnostics.ResyncReport report)
+        {
+            if (report == null) return Diagnostics.ResyncVerdict.Settled;
+            if (_session == null || _session.Status != SessionStatus.Connected)
+                return Diagnostics.ResyncVerdict.AlreadyRecovering;
+
+            Diagnostics.ResyncVerdict verdict =
+                Diagnostics.ResyncArbiter.Submit(report, NowMs, WorldRecoveryInFlight);
+            // First settled report wins; a second one this frame is a consequence of the same
+            // divergence and the one reload answers both.
+            if (verdict == Diagnostics.ResyncVerdict.Settled && _settledReport == null)
+                _settledReport = report;
+            return verdict;
+        }
+
         public void RequestAutomaticWorldRecovery(string reason)
         {
+            RequestAutomaticWorldRecovery(Diagnostics.ResyncReport.FromReason(reason));
+        }
+
+        /// <summary>
+        /// Weigh a queued report and, if it settles, reload the world. Requests that arrive here
+        /// have already let go of their work, so a held verdict simply means the world is left
+        /// alone and the arbiter keeps watching for the fault to recur.
+        /// </summary>
+        public void RequestAutomaticWorldRecovery(Diagnostics.ResyncReport report)
+        {
+            if (report == null || _session == null || _session.Status != SessionStatus.Connected) return;
+            if (Diagnostics.ResyncArbiter.Submit(report, NowMs, WorldRecoveryInFlight) !=
+                Diagnostics.ResyncVerdict.Settled) return;
+            RunAutomaticWorldRecovery(report);
+        }
+
+        /// <summary>
+        /// Reload the world for reports whose hold elapsed with nothing withdrawing them. Held is
+        /// never "dismissed": a subsystem that can retry withdraws its report when it succeeds, and
+        /// one that dropped its work simply lets the hold run out, which is what lands here.
+        /// </summary>
+        private void PumpMaturedResyncReports()
+        {
             if (_session == null || _session.Status != SessionStatus.Connected) return;
+            // A reload already running supersedes anything held: leave the evidence alone rather
+            // than announcing a verdict on it that nothing is going to act on.
+            if (WorldRecoveryInFlight) return;
+
+            // Verdicts settled inside a frame (see SettleResyncReport) are acted on here.
+            Diagnostics.ResyncReport settled = _settledReport;
+            _settledReport = null;
+            if (settled != null) RunAutomaticWorldRecovery(settled);
+
+            System.Collections.Generic.List<Diagnostics.ResyncReport> matured =
+                Diagnostics.ResyncArbiter.TakeMatured(NowMs);
+            if (matured == null || matured.Count == 0) return;
+            // One reload settles every one of them; the rest are folded into it.
+            RunAutomaticWorldRecovery(matured[0]);
+        }
+
+        private void RunAutomaticWorldRecovery(Diagnostics.ResyncReport report)
+        {
             long now = NowMs;
-            bool recovering = _worldSyncBarrierActive ||
-                              _phase == ClientWorldPhase.WaitingForMap ||
-                              _phase == ClientWorldPhase.LoadingMap ||
-                              _phase == ClientWorldPhase.WaitingForResume;
             // Guard the sentinel before subtracting it. `now - long.MinValue` wraps negative in
             // unchecked arithmetic, which otherwise makes the first automatic recovery look as if
             // it were inside the cooldown forever.
             bool coolingDown = _lastAutoRecoveryMs != long.MinValue &&
                                now - _lastAutoRecoveryMs < AutoRecoveryCooldownMs;
-            if (recovering || coolingDown)
+            if (coolingDown)
             {
-                _log.Warn("[MP] Suppressed automatic world recovery (" + reason +
-                          "): a recovery is already in progress or within the cooldown. The offending " +
-                          "edit is left un-synced; use /sync if the city looks out of step.");
-                Diagnostics.FlightRecorder.Note("auto recovery suppressed (cooldown/in-progress): " + reason);
+                Diagnostics.SyncLog.ProdWarn(
+                    "World sync: skipped a second automatic reload within " +
+                    (AutoRecoveryCooldownMs / 1000) + " s (" + report.Reason +
+                    "). The edit behind it is left un-synced; use /sync if the city looks out of step.");
+                Diagnostics.FlightRecorder.Note("auto recovery suppressed (cooldown): " + report.Summary());
                 return;
             }
             _lastAutoRecoveryMs = now;
-            _log.Warn("[MP] Requesting world recovery: " + reason + ".");
-            Diagnostics.FlightRecorder.Note("resync requested: " + reason);
-            _session.RequestWorldSync();
+            Diagnostics.SyncLog.Prod("World sync: reloading this city from the host now (" +
+                                     report.Reason + ").");
+            Diagnostics.FlightRecorder.Note("resync requested: " + report.Summary());
+            _session.RequestWorldSync(report.Reason);
         }
 
         // ---- Chat log (in-game hub panel) --------------------------------------

--- a/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldSync.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldSync.cs
@@ -82,6 +82,9 @@ namespace CS2MultiplayerMod.Game
             _worldSyncBarrierActive = true;
             _hostWorldSyncUiStage = HostWorldSyncUiStage.WaitingForQuiescence;
             SyncInbox.DrainAll();
+            // Held evidence describes the world that is about to be replaced. Keeping it would let
+            // a fault from before the barrier settle a second reload after it.
+            Diagnostics.ResyncArbiter.Reset();
             MaintainWorldSyncBarrier();
             resumeSpeed = _worldSyncResumeSpeed;
             _log.Info("[MP] World sync epoch " + epoch +
@@ -127,6 +130,7 @@ namespace CS2MultiplayerMod.Game
                     _clientQuiescenceCleanFrames = 0;
                     _clientQuiescedEpoch = 0;
                     SyncInbox.DrainAll();
+                    Diagnostics.ResyncArbiter.Reset();
                     SetPhase(ClientWorldPhase.WaitingForMap);
                     _log.Info("[MP] World sync epoch " + epoch +
                               " began; local gameplay is paused while native transactions drain.");

--- a/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldSync.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldSync.cs
@@ -150,11 +150,18 @@ namespace CS2MultiplayerMod.Game
                 _worldSyncResumeSpeed = SanitizeSpeed(resumeSpeed);
                 if (_phase != ClientWorldPhase.WaitingForResume)
                 {
-                    _log.Error("[MP] Host resumed world-sync epoch " + epoch +
-                               " before this client installed its snapshot; requesting a new epoch.");
+                    Diagnostics.SyncLog.ProdError(
+                        "World sync: the host finished epoch " + epoch +
+                        " before this city had installed its snapshot. Asking for the world again.");
                     ResetWorldSyncState(restoreSpeed: false);
                     SetPhase(ClientWorldPhase.WaitingForMap);
-                    SyncInbox.RequestResync("resume arrived before snapshot load completed");
+                    // Deliberately NOT the resync arbiter. Two things would swallow it: the session
+                    // is still inside its epoch at this point and coalesces the request away, and
+                    // the WaitingForMap phase set on the line above makes WorldRecoveryInFlight
+                    // true, which is read as "a reload is already running". Neither is the case -
+                    // nothing is coming - so the client sat in WaitingForMap for the rest of the
+                    // session, waiting for a world nobody had been asked for.
+                    RequestMapAgainNextTick();
                     return;
                 }
 

--- a/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldTransfer.cs
+++ b/CS2MultiplayerMod/Game/MultiplayerService/WorldTransfer/WorldTransfer.cs
@@ -197,6 +197,7 @@ namespace CS2MultiplayerMod.Game
             // Purge every sync inbox before the reload: queued commands describe the pre-reload
             // world and would apply stale edits (or reference vanished entities) on the new one.
             Sync.Infrastructure.SyncInbox.DrainAll();
+            Diagnostics.ResyncArbiter.Reset();
             SetPhase(ClientWorldPhase.LoadingMap);
             if (!JoinMapLoader.StageAndLoad(data, _log))
             {

--- a/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/CommandObserver.cs
+++ b/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/CommandObserver.cs
@@ -51,7 +51,11 @@ namespace CS2MultiplayerMod.Game.Sync.Infrastructure
                 {
                     WarnThrottled("[MP] Dropping oversized command id " + command.CommandId +
                                   " body=" + command.Body.Length + " > " + MaxBodyBytes + ".");
-                    SyncInbox.RequestResync("oversized sync command rejected");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("oversized sync command rejected", "stream",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                        .About("oversized command")
+                        .Tried("nothing - the command exceeded its size cap and was refused at the door"));
                     return;
                 }
                 SyncInbox.Push(_sink, command, QueueCap);

--- a/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/RealizeGate.cs
+++ b/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/RealizeGate.cs
@@ -1,0 +1,52 @@
+namespace CS2MultiplayerMod.Game.Sync.Infrastructure
+{
+    /// <summary>
+    /// One frame-scoped fact that several systems need and none of them can see for themselves:
+    /// whether remote world-building work is currently held back.
+    ///
+    /// <see cref="Systems.SyncRealizeSystem"/> already decides this each frame - terrain is behind,
+    /// or the net pipeline still has placements queued - and holds roads, zoning and zone-grown
+    /// buildings until it clears. Systems that merely WAIT on those things are not themselves
+    /// gated, so they keep running and keep counting down retry windows for targets that cannot
+    /// possibly arrive yet. When the window then expires they report a target that "did not
+    /// resolve" and ask for a full world reload, over a building the mod was still holding back.
+    ///
+    /// Reading a flag is what those systems need rather than a reference to the pipeline, hence a
+    /// static: they are constructed independently and are not wired to each other.
+    /// </summary>
+    internal static class RealizeGate
+    {
+        /// <summary>
+        /// True while roads, zoning and zone-grown buildings cannot be applied. Written once per
+        /// frame by the realize pipeline, read by anything that waits on one of them.
+        /// </summary>
+        public static bool WorldBuildingHeld;
+
+        /// <summary>Clear on a world reload or a session end - nothing is held in a world that is gone.</summary>
+        public static void Reset() => WorldBuildingHeld = false;
+    }
+
+    /// <summary>
+    /// Measures how long a system has been unable to make progress, so a retry window can be spent
+    /// on attempts rather than on wall-clock seconds. Call <see cref="Observe"/> once per frame and
+    /// add the result to every pending deadline.
+    /// </summary>
+    internal sealed class HeldTime
+    {
+        private long _lastMs;
+
+        /// <summary>
+        /// Time to add to pending deadlines this frame: the gap since the previous call when
+        /// <paramref name="held"/>, and zero otherwise. Returns zero on the first call, so a system
+        /// that starts mid-session never back-dates its first window.
+        /// </summary>
+        public long Observe(long nowMs, bool held)
+        {
+            long delta = _lastMs == 0 ? 0 : nowMs - _lastMs;
+            _lastMs = nowMs;
+            return held && delta > 0 ? delta : 0;
+        }
+
+        public void Reset() => _lastMs = 0;
+    }
+}

--- a/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/SyncInbox.cs
+++ b/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/SyncInbox.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Threading;
+using CS2MultiplayerMod.Game.Diagnostics;
 
 namespace CS2MultiplayerMod.Game.Sync.Infrastructure
 {
@@ -20,11 +21,18 @@ namespace CS2MultiplayerMod.Game.Sync.Infrastructure
         /// <summary>Sink for the rare backpressure/drain warnings (set by the mod; also by tests).</summary>
         public static Action<string> LogWarn;
 
+        /// <summary>
+        /// The synchronous resync gate, installed by the mod (see <see cref="Settle"/>). Left null
+        /// in tests, where every request settles - a test has no world to reload and no arbiter to
+        /// consult, so the historical "ask and it happens" behaviour is the right default there.
+        /// </summary>
+        public static Func<ResyncReport, ResyncVerdict> Arbitrate;
+
         private static readonly object DrainGate = new object();
         private static readonly List<Action> Drains = new List<Action>();
         private static readonly object ResyncGate = new object();
         private static int _resyncPending;
-        private static string _resyncReason;
+        private static ResyncReport _resyncReport;
 
         public static bool Push<T>(ConcurrentQueue<T> queue, T item, int cap = DefaultCap)
         {
@@ -36,7 +44,14 @@ namespace CS2MultiplayerMod.Game.Sync.Infrastructure
                 if (queue.Count <= cap) return true;
                 Clear(queue);
             }
-            RequestResync("sync inbox overflow");
+            // Shedding a queued suffix means commands were lost before they could be applied.
+            // Nothing local can supply them again, so this is not a wait-and-see.
+            RequestResync(ResyncReport
+                .Create("sync inbox overflow", "stream", ResyncEvidence.StreamLoss)
+                .About("inbox cap " + cap)
+                .Fact("queue cap", cap)
+                .Tried("shed the incomplete queued suffix rather than applying dependent work " +
+                       "without the command it depends on"));
             Action<string> warn = LogWarn;
             if (warn != null)
                 warn("[MP] Sync inbox overflowed; cleared the incomplete command suffix and " +
@@ -44,23 +59,60 @@ namespace CS2MultiplayerMod.Game.Sync.Infrastructure
             return false;
         }
 
+        /// <summary>
+        /// Ask for a world reload without evidence. Kept for the call sites that have already let
+        /// go of their work and for anything running off the main thread; the request is classified
+        /// as an unproven timeout, so the arbiter will corroborate it before any world is reloaded.
+        /// </summary>
         public static void RequestResync(string reason)
+        {
+            RequestResync(ResyncReport.FromReason(reason));
+        }
+
+        /// <summary>
+        /// Queue an evidence-carrying request for the main thread to weigh. Use this when the caller
+        /// cannot keep its work - the queue was shed, the command was malformed, the graph is gone.
+        /// A caller that CAN hold its work should use <see cref="Settle"/> instead and act on the
+        /// verdict, because a held report is a world reload that never has to happen.
+        /// </summary>
+        public static void RequestResync(ResyncReport report)
         {
             lock (ResyncGate)
             {
-                if (_resyncPending == 0) _resyncReason = reason ?? "sync pipeline recovery";
+                // First reason wins, as before: the earliest fault is the one that explains the
+                // rest, and a later request is usually a consequence of the same divergence.
+                if (_resyncPending == 0) _resyncReport = report ?? ResyncReport.FromReason(null);
                 Volatile.Write(ref _resyncPending, 1);
             }
         }
 
-        public static bool TryTakeResyncRequest(out string reason)
+        /// <summary>
+        /// Put a report to the arbiter now and get its verdict, on the main thread.
+        ///
+        /// <see cref="ResyncVerdict.Held"/> means the caller must KEEP its work queued and retry:
+        /// the fault is not proven, the mutating net feeders have been frozen for the length of the
+        /// hold, and a retry that succeeds withdraws the report instead of reloading the world.
+        /// </summary>
+        public static ResyncVerdict Settle(ResyncReport report)
         {
-            reason = null;
+            if (report == null) return ResyncVerdict.Settled;
+            Func<ResyncReport, ResyncVerdict> arbitrate = Arbitrate;
+            if (arbitrate == null)
+            {
+                RequestResync(report);
+                return ResyncVerdict.Settled;
+            }
+            return arbitrate(report);
+        }
+
+        public static bool TryTakeResyncRequest(out ResyncReport report)
+        {
+            report = null;
             if (Interlocked.Exchange(ref _resyncPending, 0) == 0) return false;
             lock (ResyncGate)
             {
-                reason = _resyncReason ?? "sync pipeline recovery";
-                _resyncReason = null;
+                report = _resyncReport ?? ResyncReport.FromReason(null);
+                _resyncReport = null;
             }
             return true;
         }

--- a/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/SyncInbox.cs
+++ b/CS2MultiplayerMod/Game/Sync/Infrastructure/Pipeline/SyncInbox.cs
@@ -60,9 +60,10 @@ namespace CS2MultiplayerMod.Game.Sync.Infrastructure
         }
 
         /// <summary>
-        /// Ask for a world reload without evidence. Kept for the call sites that have already let
-        /// go of their work and for anything running off the main thread; the request is classified
-        /// as an unproven timeout, so the arbiter will corroborate it before any world is reloaded.
+        /// Ask for a world reload without evidence. No call site in the mod does this any more -
+        /// every one of them now names what it saw - but the overload stays as the safe default for
+        /// anything added later: an unclassified request is treated as an unproven timeout, so it
+        /// is held and corroborated rather than reloading a world on nothing.
         /// </summary>
         public static void RequestResync(string reason)
         {

--- a/CS2MultiplayerMod/Game/Sync/Systems/Appearance/VisualCustomizationSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Appearance/VisualCustomizationSyncSystem.cs
@@ -671,15 +671,34 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 {
                     Mod.log.Warn("[MP] VisualCustomizationSync: dropping malformed command: " +
                                  ex.Message);
-                    SyncInbox.RequestResync("malformed visual-customization command");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("malformed visual-customization command", "appearance",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                        .About("malformed customization command")
+                        .Tried("nothing - the command could not be decoded"));
                 }
             }
         }
 
         // Re-resolving every pending command on every frame is what turns a burst of targets
         // into a stall; the retry window is measured in seconds, so this granularity is ample.
+        private readonly HeldTime _targetHold = new HeldTime();
+
         private void ApplyRetries(long now)
         {
+            // A customization waits for its building, and a zone-grown building is exactly what the
+            // realize pipeline holds back while terrain or roads catch up. Counting the window down
+            // through that hold expires it against a target that could not have arrived, and the
+            // expiry below asks for a world reload.
+            long heldMs = _targetHold.Observe(now, RealizeGate.WorldBuildingHeld);
+            if (heldMs > 0)
+                for (int h = 0; h < _retry.Count; h++)
+                {
+                    PendingVisual shifted = _retry[h];
+                    shifted.DeadlineMs += heldMs;
+                    _retry[h] = shifted;
+                }
+
             if (_retry.Count == 0) return;
             if (now - _lastRetryMs < RetryIntervalMs) return;
             _lastRetryMs = now;
@@ -701,7 +720,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             {
                 Mod.log.Warn("[MP] VisualCustomizationSync: " + expiredTargets +
                              " target(s) did not appear before the retry deadline.");
-                SyncInbox.RequestResync("visual-customization target did not resolve");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("visual-customization target did not resolve", "appearance",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                    .About("customization target")
+                    .Tried("retried every 250 ms for 10 s of attempts, not counting time the buildings were held back"));
             }
         }
 
@@ -726,7 +749,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             {
                 _retryTargetCount -= _retry[0].Command.Targets.Length;
                 _retry.RemoveAt(0);
-                SyncInbox.RequestResync("visual-customization retry budget exhausted");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("visual-customization retry budget exhausted", "appearance",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("customization retry budget")
+                    .Tried("nothing - the oldest queued customizations were shed to stay within the budget"));
             }
         }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/City/CityStateSyncSystem/CityStateSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/City/CityStateSyncSystem/CityStateSyncSystem.cs
@@ -315,7 +315,12 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             if (_orderedInvalidated) return;
             _orderedInvalidated = true;
             SyncInbox.Clear(_orderedDeferred);
-            SyncInbox.RequestResync(reason);
+            // The ordered city-state stream is revisioned: once a page is lost or refused, every
+            // later page describes a state this machine never reached. Nothing local supplies it.
+            SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                .Create(reason, "city-state", CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                .About("ordered city-state stream")
+                .Tried("nothing - the ordered stream was invalidated and its deferred pages dropped"));
         }
     }
 }

--- a/CS2MultiplayerMod/Game/Sync/Systems/City/PolicySyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/City/PolicySyncSystem/Realize.cs
@@ -15,8 +15,19 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 {
     public partial class PolicySyncSystem
     {
+        private readonly HeldTime _targetHold = new HeldTime();
+
         private void ApplyIncoming(MultiplayerSession session, long now)
         {
+            // A policy waits for the building it applies to, and a zone-grown building is what the
+            // realize pipeline holds back while terrain or roads catch up. See RealizeGate: without
+            // this the window expires against a target that could not yet have arrived.
+            long heldMs = _targetHold.Observe(now, RealizeGate.WorldBuildingHeld);
+            if (heldMs > 0)
+                for (int h = 0; h < _targetRetry.Count; h++)
+                    _targetRetry[h] = (_targetRetry[h].cmd, _targetRetry[h].origin,
+                        _targetRetry[h].deadline + heldMs);
+
             for (int i = 0; i < _targetRetry.Count;)
             {
                 var pending = _targetRetry[i];
@@ -33,7 +44,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                  (TargetRetryWindowMs / 1000) + " s for policy '" +
                                  pending.cmd.PolicyPrefabName +
                                  "'; requesting world recovery.");
-                    SyncInbox.RequestResync("policy target did not resolve");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("policy target did not resolve", "policy",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                        .About("policy target building")
+                        .Tried("retried for 15 s of attempts, not counting time the buildings were held back"));
                     _targetRetry.RemoveAt(i);
                     continue;
                 }
@@ -85,7 +100,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             {
                 Mod.log.Error("[MP] PolicySync realize FAILED for '" +
                               command.PolicyPrefabName + "': " + ex);
-                SyncInbox.RequestResync("building policy application failed");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("building policy application failed", "policy",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("policy application")
+                    .Tried("nothing - applying the policy threw"));
             }
             return true;
         }
@@ -105,7 +124,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 _targetRetry.RemoveAt(0);
                 Mod.log.Warn("[MP] PolicySync: pending-target queue reached its bounded limit; " +
                              "requesting world recovery.");
-                SyncInbox.RequestResync("policy target retry queue overflow");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("policy target retry queue overflow", "policy",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("policy retry queue")
+                    .Tried("nothing - the oldest queued policy was shed to stay within the bound"));
             }
             _targetRetry.Add((command, origin, now + TargetRetryWindowMs));
             Diagnostics.FlightRecorder.Note("policy target retrying kind=" +

--- a/CS2MultiplayerMod/Game/Sync/Systems/Land/AreaSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Land/AreaSyncSystem/Realize.cs
@@ -53,7 +53,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 _ownedAreaRetry.Clear();
                 Diagnostics.FlightRecorder.Note(
                     "owned area retry queue overflow; recovery requested");
-                SyncInbox.RequestResync("owned area retry queue overflow");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("owned area retry queue overflow", "area",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("owned area retry queue")
+                    .Tried("nothing - the queue was full and was cleared"));
             }
             _ownedAreaRetry.Add((command, originPlayerId, deadline));
         }

--- a/CS2MultiplayerMod/Game/Sync/Systems/Land/TerrainSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Land/TerrainSyncSystem.cs
@@ -36,9 +36,37 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
     /// </summary>
     public partial class TerrainSyncSystem : GameSystemBase
     {
-        // Receiver apply budget: brush samples materialised per frame. Terrain's capture rate
-        // (≤ ~60 samples/s) is far below this, so the budget only bites on a backlog drain.
-        private const int MaxApplyPerFrame = 64;
+        /// <summary>
+        /// Receiver apply budget: brush samples materialised per frame.
+        ///
+        /// The budget exists to bound one frame's spike, NOT to pace normal play. A player's own
+        /// terraforming produces at most about sixty samples a second, so at sixty frames a second
+        /// this only ever bites on a backlog - and a backlog is exactly when spreading the work out
+        /// is the wrong thing to do: <see cref="HasBacklog"/> holds back every road, building, zone,
+        /// growable and route realize until terrain is level with the sender's, so every extra frame
+        /// spent draining is a frame in which nothing else in the session can be applied either.
+        ///
+        /// The game applies whatever brushes exist in a single <c>ApplyBrushesSystem</c> pass, so a
+        /// larger batch is one bigger frame, not more frames. Sixty-four was arbitrary and made a
+        /// single terraforming stroke take several frames to land; five hundred and twelve covers
+        /// roughly eight seconds of continuous terraforming, which is longer than a stroke anyone
+        /// draws in one go, and leaves the ceiling only for the pathological case.
+        ///
+        /// It also makes the replay slightly more faithful: a height brush is a rate, rescaled per
+        /// sample by this machine's frame time, so applying a stroke's samples together under one
+        /// frame time reproduces it more exactly than spreading them over frames of varying length.
+        /// </summary>
+        private const int MaxApplyPerFrame = 512;
+
+        /// <summary>
+        /// How long the apply may stay unavailable before the queued samples are given up on.
+        ///
+        /// Without a bound this was a session-ending wedge rather than a lost stroke: samples that
+        /// can never be applied keep <see cref="HasBacklog"/> true forever, and that flag gates
+        /// every other realize in the mod. Reaching this means terrain here no longer matches the
+        /// sender's, which is a divergence worth repairing rather than one to play on.
+        /// </summary>
+        private const int MaxCommitFailureFrames = 300;
 
         // Decoder scan budget: commands pulled off the inbox per frame, so a malformed/unknown-prefab
         // flood cannot create an unbounded main-thread loop.
@@ -67,6 +95,17 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 
         private long _diagStartMs = -1;
         private int _diagCaptured, _diagRealized;
+
+        // Terrain that never left this machine, or never arrived on it. Every one of these paths
+        // used to be a silent `continue`, and a terraform that goes missing is not a small error:
+        // one stroke is metres of height, and the roads placed near it afterwards resolve their
+        // endpoints against a surface the other player does not have. Counted here and reported at
+        // the production level, because this is the thing a session that "keeps de-syncing" needs
+        // its log to say out loud.
+        private int _dropSendNoToolName, _dropSendNoBrushName, _dropSendOpacity, _dropSendBadFrame;
+        private int _dropApplyUnknownPrefab, _dropApplyUnusablePrefab, _dropApplyCreateFailed;
+        private int _dropApplyMalformed, _dropApplyUnavailable;
+        private int _commitFailureFrames;
 
         protected override void OnCreate()
         {
@@ -121,6 +160,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             _pending.Clear();
             _awaitingHeightReadback = false;
             _commitApplyFailureLogged = false;
+            _commitFailureFrames = 0;
         }
 
         protected override void OnUpdate()
@@ -202,16 +242,30 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 
                 TerrainBrushCommand command;
                 try { command = TerrainBrushCommand.Decode(message.Body); }
-                catch (System.Exception ex) { Mod.log.Warn("[MP] TerrainSync: dropping malformed command: " + ex.Message); continue; }
+                catch (System.Exception ex)
+                {
+                    _dropApplyMalformed++;
+                    Mod.log.Warn("[MP] TerrainSync: dropping malformed command: " + ex.Message);
+                    continue;
+                }
 
                 Entity tool, brush;
                 if (!_prefabIndex.TryResolve(command.ToolPrefabName, out tool) ||
-                    !_prefabIndex.TryResolve(command.BrushPrefabName, out brush)) continue;
+                    !_prefabIndex.TryResolve(command.BrushPrefabName, out brush))
+                {
+                    _dropApplyUnknownPrefab += command.Samples.Length;
+                    continue;
+                }
                 // ApplyBrushesSystem dereferences TerraformingData[tool] and BrushData/BrushCell[brush]
                 // with no existence check — a wrong prefab type there is a native crash, not an
                 // exception. Only queue a sample whose prefabs carry them.
-                if (!EntityManager.HasComponent<TerraformingData>(tool)) continue;
-                if (!EntityManager.HasComponent<BrushData>(brush) || !EntityManager.HasBuffer<BrushCell>(brush)) continue;
+                if (!EntityManager.HasComponent<TerraformingData>(tool) ||
+                    !EntityManager.HasComponent<BrushData>(brush) ||
+                    !EntityManager.HasBuffer<BrushCell>(brush))
+                {
+                    _dropApplyUnusablePrefab += command.Samples.Length;
+                    continue;
+                }
 
                 for (int i = 0; i < command.Samples.Length; i++)
                     _pending.Add((tool, brush, command.Samples[i]));
@@ -226,30 +280,49 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 
             _netSync.PrepareAuxiliaryTemps();
 
+            // Take the whole arrived stroke in one pass. ApplyBrushesSystem consumes every Temp
+            // brush that exists in a single Update, so a bigger batch is one bigger frame rather
+            // than more frames - and every extra frame here is a frame in which no road, building,
+            // zone or route may be applied either (see HasBacklog).
             int candidateCount = System.Math.Min(MaxApplyPerFrame, _pending.Count);
             var created = new List<Entity>(candidateCount);
+            int consumed = 0;
             bool changesHeight = false;
-            try
+            for (int i = 0; i < candidateCount; i++)
             {
-                for (int i = 0; i < candidateCount; i++)
+                var item = _pending[i];
+                consumed++;
+                try
                 {
-                    var item = _pending[i];
                     bool sampleChangesHeight;
                     created.Add(CreateRemoteBrush(item.tool, item.brush, item.sample,
                         out sampleChangesHeight));
                     changesHeight |= sampleChangesHeight;
                 }
+                catch (System.Exception ex)
+                {
+                    // Skip the one sample that threw rather than abandoning the batch. Rejecting
+                    // the whole batch and leaving it queued meant a single bad sample kept
+                    // HasBacklog true forever, and that flag holds back every other realize in the
+                    // mod - a lost stroke turned into a session that could apply nothing at all.
+                    _dropApplyCreateFailed++;
+                    Mod.log.Warn("[MP] TerrainSync: dropping a brush sample that could not be " +
+                                 "created: " + ex.Message);
+                }
             }
-            catch (System.Exception ex)
+
+            if (created.Count == 0)
             {
-                DestroyUncommittedBrushes(created);
-                Mod.log.Warn("[MP] TerrainSync: could not create remote brush batch: " + ex.Message);
+                // Nothing to commit, but these samples are spent - queueing them again would retry
+                // the same failure forever. The brush isolation taken above is released by
+                // FinishIsolationAfterToolOutput at the end of this frame either way.
+                if (consumed > 0) _pending.RemoveRange(0, consumed);
                 return;
             }
 
             bool committed = false;
             string commitError = null;
-            try { committed = created.Count > 0 && _netSync.CommitAuxiliaryTempsNow(); }
+            try { committed = _netSync.CommitAuxiliaryTempsNow(); }
             catch (System.Exception ex)
             {
                 commitError = ex.Message;
@@ -264,15 +337,51 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     Mod.log.Warn("[MP] TerrainSync: brush apply unavailable; remote samples remain queued" +
                                  (string.IsNullOrEmpty(commitError) ? "." : ": " + commitError));
                 }
+                // Bounded. An apply that never becomes available is not something to wait out: the
+                // queue it blocks is the one every other sync system waits behind.
+                if (++_commitFailureFrames >= MaxCommitFailureFrames) GiveUpOnQueuedTerrain(commitError);
                 return;
             }
 
+            // The apply pass consumes every Temp brush that exists when it runs; the samples are
+            // spent whether or not their Applied tag is visible yet (it is stamped through the tool
+            // barrier and only becomes observable at ModificationEnd, which is why the capture
+            // query reads it there). This is the same contract the smaller batch relied on.
             _commitApplyFailureLogged = false;
-            _pending.RemoveRange(0, created.Count);
+            _commitFailureFrames = 0;
+            _pending.RemoveRange(0, consumed);
             if (changesHeight) _awaitingHeightReadback = true;
             _diagRealized += created.Count;
             Diagnostics.FlightRecorder.Note("terrain realize n=" + created.Count +
                 (_pending.Count > 0 ? " held=" + _pending.Count : ""));
+        }
+
+        /// <summary>
+        /// Abandon terrain this machine cannot apply. The samples are dropped so the backlog flag
+        /// clears and the rest of the mod can run again, and the divergence they leave behind is
+        /// put to the resync arbiter as what it is: ground that is now a different shape here.
+        /// </summary>
+        private void GiveUpOnQueuedTerrain(string commitError)
+        {
+            int abandoned = _pending.Count;
+            _pending.Clear();
+            _commitFailureFrames = 0;
+            _commitApplyFailureLogged = false;
+            _dropApplyUnavailable += abandoned;
+
+            Diagnostics.SyncLog.ProdWarn(
+                "Terrain sync: gave up on " + abandoned + " queued terraforming sample(s) after " +
+                MaxCommitFailureFrames + " frames without a usable apply pass" +
+                (string.IsNullOrEmpty(commitError) ? "." : " (" + commitError + ").") +
+                " The ground here no longer matches the other player's.");
+            SyncInbox.RequestResync(Diagnostics.ResyncReport
+                .Create("queued terraforming could not be applied", "terrain",
+                    Diagnostics.ResyncEvidence.Contradiction)
+                .About("terrain apply pass")
+                .Tried("held the samples for " + MaxCommitFailureFrames +
+                       " frames waiting for a frame the game would apply brushes on")
+                .Fact("samples abandoned", abandoned)
+                .Fact("why the apply was refused", commitError ?? "the brush apply system was unavailable"));
         }
 
         private Entity CreateRemoteBrush(Entity tool, Entity brushPrefab, TerrainBrushCommand.Sample s,
@@ -336,22 +445,35 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 // Batch consecutive samples that share a tool+brush into one command (a fast small
                 // brush drag applies many samples per frame).
                 var batches = new Dictionary<(string tool, string brush), List<TerrainBrushCommand.Sample>>();
+                // A hitch, a resumed frame or a first frame gives a delta that says nothing about
+                // how long this stroke was applied for. Returning here dropped every sample in the
+                // frame - the ground moved locally and the other player was never told, which is a
+                // permanent divergence bought to avoid one mis-scaled sample. Fall back to a normal
+                // frame instead: the height rate is then slightly off and the periodic sync trues
+                // it, where a dropped stroke is never trued at all.
+                const float FallbackFrameSeconds = 1f / 60f;
                 float sourceDelta = UnityEngine.Time.unscaledDeltaTime;
                 if (sourceDelta <= 0f || sourceDelta > 10f ||
-                    float.IsNaN(sourceDelta) || float.IsInfinity(sourceDelta)) return;
+                    float.IsNaN(sourceDelta) || float.IsInfinity(sourceDelta))
+                {
+                    _dropSendBadFrame += entities.Length;
+                    sourceDelta = FallbackFrameSeconds;
+                }
                 for (int i = 0; i < entities.Length; i++)
                 {
                     Brush brush = EntityManager.GetComponentData<Brush>(entities[i]);
 
                     string toolName = _prefabSystem.GetPrefabName(brush.m_Tool);
-                    if (string.IsNullOrEmpty(toolName)) continue;
+                    if (string.IsNullOrEmpty(toolName)) { _dropSendNoToolName++; continue; }
                     string brushName = _prefabSystem.GetPrefabName(
                         EntityManager.GetComponentData<PrefabRef>(entities[i]).m_Prefab);
-                    if (string.IsNullOrEmpty(brushName)) continue;
+                    if (string.IsNullOrEmpty(brushName)) { _dropSendNoBrushName++; continue; }
 
                     // A cancelled/preview brush carries opacity outside (0,1] or no real edit — the
                     // wire guard would reject it anyway; skip so a batch never fails to encode.
-                    if (brush.m_Opacity <= 0f || brush.m_Opacity > 1f) continue;
+                    // Counted rather than skipped silently: this query only sees APPLIED brushes, so
+                    // anything refused here did change the ground and did not travel.
+                    if (brush.m_Opacity <= 0f || brush.m_Opacity > 1f) { _dropSendOpacity++; continue; }
 
                     var key = (toolName, brushName);
                     List<TerrainBrushCommand.Sample> list;
@@ -408,8 +530,63 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             if (now - _diagStartMs < 5000) return;
             if (_diagCaptured > 0 || _diagRealized > 0)
                 Mod.Verbose("[MP] TerrainSync/5s: captured " + _diagCaptured + " sample(s), realized " + _diagRealized + ".");
+            ReportDroppedTerrain();
             _diagCaptured = _diagRealized = 0;
             _diagStartMs = now;
+        }
+
+        /// <summary>
+        /// Say out loud what terrain went missing, and on which side.
+        ///
+        /// Each of these was a bare <c>continue</c>. A terraforming stroke is metres of height, so
+        /// one dropped sample is not a rounding error - it is ground that is a different shape on
+        /// the two machines, and the roads drawn near it afterwards resolve their endpoints against
+        /// a surface the sender does not have. The realize pass already reports elevation
+        /// corrections of over three metres; this is where such a figure comes from.
+        /// </summary>
+        private void ReportDroppedTerrain()
+        {
+            int notSent = _dropSendNoToolName + _dropSendNoBrushName + _dropSendOpacity;
+            int notApplied = _dropApplyUnknownPrefab + _dropApplyUnusablePrefab +
+                             _dropApplyCreateFailed + _dropApplyMalformed;
+
+            if (notSent > 0)
+                Diagnostics.SyncLog.ProdWarn(
+                    "Terrain sync: " + notSent + " terraforming sample(s) changed the ground here " +
+                    "but could not be sent (" + _dropSendNoToolName + " with no tool name, " +
+                    _dropSendNoBrushName + " with no brush name, " + _dropSendOpacity +
+                    " outside the encodable range). The other player's ground is now different here.");
+
+            if (notApplied > 0)
+                Diagnostics.SyncLog.ProdWarn(
+                    "Terrain sync: " + notApplied + " terraforming sample(s) arrived but could not " +
+                    "be applied (" + _dropApplyUnknownPrefab + " naming a tool or brush this game " +
+                    "does not have, " + _dropApplyUnusablePrefab + " naming one that cannot " +
+                    "terraform, " + _dropApplyCreateFailed + " that failed to build, " +
+                    _dropApplyMalformed + " malformed). The ground here is now different from the " +
+                    "other player's.");
+
+            if (_dropSendBadFrame > 0)
+                Diagnostics.SyncLog.ProdWarn(
+                    "Terrain sync: " + _dropSendBadFrame + " terraforming sample(s) were sent with " +
+                    "a substitute frame time because this machine reported an implausible one. " +
+                    "Their height change may be slightly off on the other player's map.");
+
+            if (notSent > 0 || notApplied > 0 || _dropSendBadFrame > 0 || _dropApplyUnavailable > 0)
+                Diagnostics.FlightRecorder.Note(
+                    "terrain dropped sendNoTool=" + _dropSendNoToolName +
+                    " sendNoBrush=" + _dropSendNoBrushName +
+                    " sendOpacity=" + _dropSendOpacity +
+                    " sendBadFrame=" + _dropSendBadFrame +
+                    " applyUnknownPrefab=" + _dropApplyUnknownPrefab +
+                    " applyUnusablePrefab=" + _dropApplyUnusablePrefab +
+                    " applyCreateFailed=" + _dropApplyCreateFailed +
+                    " applyMalformed=" + _dropApplyMalformed +
+                    " applyUnavailable=" + _dropApplyUnavailable);
+
+            _dropSendNoToolName = _dropSendNoBrushName = _dropSendOpacity = _dropSendBadFrame = 0;
+            _dropApplyUnknownPrefab = _dropApplyUnusablePrefab = _dropApplyCreateFailed = 0;
+            _dropApplyMalformed = _dropApplyUnavailable = 0;
         }
     }
 }

--- a/CS2MultiplayerMod/Game/Sync/Systems/Land/ZoneSyncSystem/Capture.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Land/ZoneSyncSystem/Capture.cs
@@ -101,7 +101,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     bool coalesced = _outgoing.ContainsKey(blockKey);
                     if (!_outgoing.TrySetLatest(blockKey, command, MaxBufferedOutgoingZones))
                     {
-                        SyncInbox.RequestResync("zone outgoing latest-state queue overflow");
+                        SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                            .Create("zone outgoing latest-state queue overflow", "zone",
+                                CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                            .About("outgoing zone queue")
+                            .Tried("nothing - zoning changes were shed before they could be sent"));
                         if (!_outgoingOverflowWarned)
                         {
                             _outgoingOverflowWarned = true;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Land/ZoneSyncSystem/ZoneSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Land/ZoneSyncSystem/ZoneSyncSystem.cs
@@ -267,7 +267,10 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             SyncInbox.Clear(_incoming);
             _ready.Clear();
             _pending.Clear();
-            SyncInbox.RequestResync(reason);
+            SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                .Create(reason, "zone", CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                .About("zone latest-state queue")
+                .Tried("nothing - the bounded queue was full and its zoning changes were shed"));
             Mod.log.Warn("[MP] ZoneSync overflowed its bounded latest-state queue; " +
                          "requesting a fresh world sync.");
         }

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetReplaceSyncSystem/NetReplaceSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetReplaceSyncSystem/NetReplaceSyncSystem.cs
@@ -68,10 +68,22 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         // them. Edges shorter than a few times this are skipped as ambiguous.
         private const float EndpointMatchTol = 2f;
 
+        /// <summary>
+        /// Set by <see cref="SyncRealizeSystem"/> while a remote placement is still waiting for the
+        /// road it anchors to. A replacement can only change or remove that road out from under the
+        /// placement, so it waits - and its own retry windows are extended by the time it waited,
+        /// because a replacement dropped for "not resolving" while it was not allowed to look is
+        /// the same divergence, one step later.
+        /// </summary>
+        public bool DeferForPendingPlacement;
+
         private readonly ConcurrentQueue<SimulationCommandMessage> _incoming =
             new ConcurrentQueue<SimulationCommandMessage>();
         private readonly List<(NetReplaceCommand command, long deadline)> _retry =
             new List<(NetReplaceCommand, long)>();
+
+        /// <summary>When this system last got to run a match pass. See RealizePending.</summary>
+        private long _lastReplaceRealizeMs;
 
         // Replacements whose armed commit was destroyed before it ran (the player's tool cleared the
         // Temps — see NetSyncSystem's commit-lost handling). Unlike _retry these carry no deadline:
@@ -199,6 +211,8 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             _retry.Clear();
             _replayCommands.Clear();
             _expectedMixedGeometryChanges.Clear();
+            _lastReplaceRealizeMs = 0;
+            DeferForPendingPlacement = false;
             _seeded = false;
         }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetReplaceSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetReplaceSyncSystem/Realize.cs
@@ -34,7 +34,14 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             // applies), leave incoming commands and retries queued for the next cycle — RealizePending
             // runs after DeleteSync, so a delete armed this frame defers us. A selected build tool is
             // allowed on quiet preview frames; only its actual Apply/Clear frame has priority.
-            if (_netSync == null || !_netSync.CanBuildDefinitions) return;
+            if (DeferForPendingPlacement || _netSync == null || !_netSync.CanBuildDefinitions)
+            {
+                // Time locked out is not the replacement's fault: its window is for waiting on its
+                // own target to arrive, not for waiting on this system to be allowed to run.
+                ExtendPendingReplaceWindows(service.NowMs);
+                return;
+            }
+            _lastReplaceRealizeMs = service.NowMs;
 
             long now = service.NowMs;
             List<(NetReplaceCommand cmd, long deadline)> work = null;
@@ -72,7 +79,13 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                  " s; dropping them and requesting authoritative world recovery.");
                     // One request for this expiry pass, not one per command. The expired entries were
                     // removed above, so they cannot request recovery again on later frames.
-                    SyncInbox.RequestResync("road replacement target did not resolve");
+                    SyncInbox.RequestResync(Diagnostics.ResyncReport
+                        .Create("road replacement target did not resolve", "net",
+                            Diagnostics.ResyncEvidence.MissingTarget)
+                        .About("road replacement")
+                        .Tried("rescanned the city's roads for the replaced span every cycle for " +
+                               (RetryWindowMs / 1000) + " s")
+                        .Fact("replacements that found no road here", expired));
                 }
             }
 
@@ -89,6 +102,15 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             }
 
             if (work != null && work.Count > 0) Apply(work, now);
+        }
+
+        private void ExtendPendingReplaceWindows(long now)
+        {
+            long frozenMs = _lastReplaceRealizeMs == 0 ? 0 : now - _lastReplaceRealizeMs;
+            _lastReplaceRealizeMs = now;
+            if (frozenMs <= 0) return;
+            for (int i = 0; i < _retry.Count; i++)
+                _retry[i] = (_retry[i].command, _retry[i].deadline + frozenMs);
         }
 
         private void Apply(List<(NetReplaceCommand cmd, long deadline)> commands, long now)

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Apply.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Apply.cs
@@ -19,8 +19,31 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
         /// <summary>How long an armed batch may wait for its commit before it is discarded and re-queued.</summary>
         private const int ApplyWindowMs = 3000;
 
-        /// <summary>How long a committed batch's Temps may linger before recovery is requested.</summary>
+        /// <summary>
+        /// How long a committed batch's Temps may linger before recovery is considered.
+        ///
+        /// This is the base for a SMALL batch. The native apply pass is per-entity work, so a fixed
+        /// window silently means "the bigger the edit, the less time it gets": a 311-Temp road
+        /// replacement was quarantined here on the same three seconds that comfortably drained the
+        /// 55- and 86-Temp batches around it. See <see cref="DrainWindowFor"/>.
+        /// </summary>
         private const int DrainWindowMs = 3000;
+
+        /// <summary>Extra drain time per tracked Temp, on top of <see cref="DrainWindowMs"/>.</summary>
+        private const int DrainWindowMsPerTemp = 12;
+
+        /// <summary>Ceiling, so a pathological batch still reaches a verdict.</summary>
+        private const int MaxDrainWindowMs = 15000;
+
+        /// <summary>
+        /// The drain budget for a batch of <paramref name="temps"/> entities. Linear in the work
+        /// the native pipeline actually has to do, and capped.
+        /// </summary>
+        private static int DrainWindowFor(int temps)
+        {
+            long budget = DrainWindowMs + (long)DrainWindowMsPerTemp * (temps > 0 ? temps : 0);
+            return budget > MaxDrainWindowMs ? MaxDrainWindowMs : (int)budget;
+        }
 
         /// <summary>
         /// A wall-clock stall is not evidence that the native pipeline is stuck. Observe several
@@ -136,7 +159,16 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             else if (_awaitingDrain)
             {
                 _drainFrames++;
-                bool committedTempsRemain = CommittedRemoteTempsRemain();
+                int remainingTemps = CountCommittedRemoteTempsRemaining();
+                bool committedTempsRemain = remainingTemps > 0;
+                // Progress is progress. A large graph leaves Temp state in waves, and the window
+                // exists to catch a pipeline that has STOPPED, not one that is merely slow. Every
+                // frame that retires at least one Temp buys the rest of the batch a fresh window.
+                if (remainingTemps < _drainRemainingTemps)
+                {
+                    _drainRemainingTemps = remainingTemps;
+                    _drainArmTick = System.Environment.TickCount;
+                }
                 if (!committedTempsRemain)
                 {
                     if (++_drainCleanFrames >= RequiredCleanDrainFrames)
@@ -152,6 +184,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                         if (completed != null) completed();
                         Diagnostics.FlightRecorder.Note(
                             "remote transaction drain completed after clean-frame fence");
+                        WithdrawDrainReport("the batch drained on its own");
                     }
                 }
                 else
@@ -161,10 +194,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
 
                 if (committedTempsRemain &&
                     _drainFrames >= MinimumDrainFramesBeforeRecovery &&
-                    System.Environment.TickCount - _drainArmTick > DrainWindowMs)
+                    System.Environment.TickCount - _drainArmTick >
+                        DrainWindowFor(_committingRemoteNetTemps.Count))
                 {
+                    int trackedCount = _committingRemoteNetTemps.Count;
                     TrackInvalidatedTemps(_committingRemoteNetTemps);
-                    int quarantinedCount = _committingRemoteNetTemps.Count;
                     // Apply has already been scheduled for this graph. Tagging its entities Deleted
                     // here races the native apply/cleanup jobs and was the immediate precursor to a
                     // process crash. Leave the graph intact, keep its identities quarantined, and
@@ -182,14 +216,24 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                     _invalidatedDrainArmTick = System.Environment.TickCount;
                     _invalidatedCleanFrames = 0;
                     _invalidatedDrainTimedOut = false;
-                    Mod.log.Warn("[MP] NetApply: isolated remote commit remained Temp after " +
-                                 _drainFrames + " frames (tracked=" + quarantinedCount +
-                                 "); quarantined without destructive cleanup and requesting " +
-                                 "world recovery.");
                     Diagnostics.FlightRecorder.Note(
                         "net isolated commit quarantined frames=" + _drainFrames +
-                        " tracked=" + quarantinedCount);
-                    SyncInbox.RequestResync("remote transaction failed to drain");
+                        " tracked=" + trackedCount + " remaining=" + remainingTemps);
+
+                    // The graph is quarantined either way - it may not be touched while native work
+                    // is still scheduled against it. Whether that costs a world reload is a
+                    // separate question, and one a stall alone does not answer.
+                    string drainSubject = "commit of " + trackedCount + " entities";
+                    NoteDrainReport(drainSubject);
+                    SyncInbox.RequestResync(Diagnostics.ResyncReport
+                        .Create(DrainFailedReason, "net", Diagnostics.ResyncEvidence.Timeout)
+                        .About(drainSubject)
+                        .Tried("waited " + _drainFrames + " frames and " +
+                               DrainWindowFor(trackedCount) + " ms, restarting the window on every " +
+                               "frame that retired at least one entity")
+                        .Fact("entities in the commit", trackedCount)
+                        .Fact("still not applied", remainingTemps)
+                        .Fact("frames waited", _drainFrames));
                 }
             }
 
@@ -548,6 +592,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             _drainArmTick = System.Environment.TickCount;
             _drainFrames = 0;
             _drainCleanFrames = 0;
+            _drainRemainingTemps = int.MaxValue;
             _suppressCaptureThisFrame = true;
             _clearLocalNetIsolationAfterBarrier = true;
             Diagnostics.FlightRecorder.Note("remote " +
@@ -639,18 +684,29 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                 " sharedOriginal=" + sharedOriginals + " members=[" + detail + "]");
         }
 
-        private bool CommittedRemoteTempsRemain()
+        /// <summary>
+        /// How many of the committed batch's entities are still Temp.
+        ///
+        /// The count, not just "any": it is what tells a stuck pipeline apart from a slow one, and
+        /// it is what the quarantine line used to be missing - it reported the batch size, so a
+        /// graph that was one entity from done and one that had not moved at all logged the same
+        /// number.
+        /// </summary>
+        private int CountCommittedRemoteTempsRemaining()
         {
+            int remaining = 0;
             for (int i = 0; i < _committingRemoteNetTemps.Count; i++)
             {
                 Entity entity = _committingRemoteNetTemps[i];
                 // Deleted is only a request to the deferred cleanup pipeline. Treating that tag as
                 // "gone" allowed the next native transaction to reuse a graph still being torn down.
                 if (EntityManager.Exists(entity) && EntityManager.HasComponent<Temp>(entity))
-                    return true;
+                    remaining++;
             }
-            return false;
+            return remaining;
         }
+
+        private bool CommittedRemoteTempsRemain() => CountCommittedRemoteTempsRemaining() > 0;
 
         private void InvalidateArmedBatch(string reason, int count)
         {
@@ -702,15 +758,56 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                                      : "."));
                 Diagnostics.FlightRecorder.Note("net batch invalidated; dropped" +
                     (repeatsPreviousAttempt ? " (rejection is deterministic)" : string.Empty));
-                SyncInbox.RequestResync(repeatsPreviousAttempt
-                    ? "remote transaction rejected deterministically"
-                    : "remote transaction exhausted bounded replays");
+                SyncInbox.RequestResync(Diagnostics.ResyncReport
+                    .Create(repeatsPreviousAttempt
+                            ? "remote transaction rejected deterministically"
+                            : "remote transaction exhausted bounded replays",
+                        "net", Diagnostics.ResyncEvidence.Contradiction)
+                    .About(identity)
+                    .Tried(replay == null
+                        ? "nothing - this batch had no way to be rebuilt"
+                        : "rebuilt and re-applied the batch " + _applyReplayBudget.AttemptsUsed +
+                          " time(s) out of " + _applyReplayBudget.MaximumAttempts)
+                    .Fact("why the batch was refused", reason)
+                    .Fact("entities in the batch", count)
+                    .Fact("the same refusal repeated", repeatsPreviousAttempt));
             }
 
             _invalidatedBatchDraining = true;
             _invalidatedDrainArmTick = System.Environment.TickCount;
             _invalidatedCleanFrames = 0;
             _invalidatedDrainTimedOut = false;
+        }
+
+        /// <summary>The reason a stalled drain reports, shared by the report and its withdrawal.</summary>
+        internal const string DrainFailedReason = "remote transaction failed to drain";
+
+        /// <summary>
+        /// What the outstanding "failed to drain" reports are about, so each can be withdrawn by
+        /// name. A list, not one field: a graph that misses its commit window and then misses its
+        /// quarantine window raises two, and withdrawing only the second would still reload the
+        /// world for the first after the graph had actually finished.
+        /// </summary>
+        private readonly List<string> _outstandingDrainSubjects = new List<string>();
+
+        private void NoteDrainReport(string subject)
+        {
+            if (!_outstandingDrainSubjects.Contains(subject))
+                _outstandingDrainSubjects.Add(subject);
+        }
+
+        /// <summary>
+        /// Take back every outstanding "failed to drain" report. A drain that finishes late is a
+        /// window that was too short, and the log should say so instead of the world reloading.
+        /// </summary>
+        private void WithdrawDrainReport(string outcome)
+        {
+            if (_outstandingDrainSubjects.Count == 0) return;
+            long now = Mod.Service != null ? Mod.Service.NowMs : 0L;
+            for (int i = 0; i < _outstandingDrainSubjects.Count; i++)
+                Diagnostics.ResyncArbiter.Withdraw("net", DrainFailedReason,
+                    _outstandingDrainSubjects[i], now, outcome);
+            _outstandingDrainSubjects.Clear();
         }
 
         /// <summary>
@@ -783,11 +880,18 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                 {
                     _invalidatedDrainTimedOut = true;
                     _replayAfterInvalidatedDrain = null;
-                    Mod.log.Error("[MP] NetApply: quarantined native transaction did not leave Temp " +
-                                  "state; blocking further native work and requesting world recovery.");
+                    Diagnostics.SyncLog.ProdError(
+                        "Road sync: a rejected road transaction is still held by the game's own " +
+                        "apply pass; no further road work can run until it finishes.");
                     Diagnostics.FlightRecorder.Note(
                         "quarantined net temps failed to drain; native work remains blocked");
-                    SyncInbox.RequestResync("quarantined native transaction failed to drain");
+                    NoteDrainReport("quarantined graph");
+                    SyncInbox.RequestResync(Diagnostics.ResyncReport
+                        .Create(DrainFailedReason, "net", Diagnostics.ResyncEvidence.Timeout)
+                        .About("quarantined graph")
+                        .Tried("waited " + DrainWindowMs + " ms for the game's apply pass to " +
+                               "release the rejected entities")
+                        .Fact("entities still held", _invalidatedRemoteTemps.Count));
                 }
                 return;
             }
@@ -804,6 +908,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             _invalidatedDrainTimedOut = false;
             _drainReleasedThisFrame = true;
             Diagnostics.FlightRecorder.Note("invalidated net transaction fully drained");
+            // It drained after all. Withdraw the report before its hold matures: the window was
+            // too short for this batch, which is a tuning fact, not a reason to reload a world.
+            WithdrawDrainReport("the game's apply pass finished the batch after the window expired");
             if (replay != null) replay();
         }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Course.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Course.cs
@@ -189,21 +189,31 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
         }
 
         /// <summary>
-        /// Project a utility endpoint's source-relative elevation onto this machine's surface for
+        /// Project an endpoint's source-relative elevation onto this machine's surface for
         /// connection lookup only. The committed geometry still uses <see cref="EndElevation"/> and
         /// therefore preserves the source height unless an existing node is actually reused.
         /// Trying raw source Y first remains important for already-synchronised geometry; this
-        /// alternate catches a locally-created pipe/cable node whose terrain or water reference
-        /// differs from the sender's by more than the vertical snap tolerance.
+        /// alternate catches a locally-created node whose terrain or water reference differs from
+        /// the sender's by more than the vertical snap tolerance.
+        ///
+        /// <paramref name="anyLayer"/> widens it past pipes and cables to roads and rails. It is
+        /// set only on the last-resort pass, once an operation has already spent a full retry
+        /// window, and it closes a gap the mod's own diagnostics had been reporting for a while:
+        /// the surface under a road endpoint routinely drifts by more than
+        /// <see cref="VerticalSnapTol"/> between two machines (the realize pass logs corrections of
+        /// over three metres), and past that point the endpoint cannot be matched at all - so a
+        /// perfectly ordinary road drawn near drifted ground could only ever end in a world reload.
+        /// Identity stays strict either way: prefab, layer contract, owner and curve direction are
+        /// still required, so only the height reference moves.
         /// </summary>
-        private bool TryProjectUtilityEndpointToLocalSurface(Entity prefab, NetPrefabInfo placedInfo,
-            float3 sourcePoint, float2 sourceElevation,
+        private bool TryProjectEndpointToLocalSurface(Entity prefab, NetPrefabInfo placedInfo,
+            float3 sourcePoint, float2 sourceElevation, bool anyLayer,
             ref TerrainHeightData heightData, ref WaterSurfaceData<SurfaceWater> waterData,
             out float3 projected)
         {
             projected = sourcePoint;
             Layer utilityLayers = placedInfo.RequiredLayers | placedInfo.ConnectLayers;
-            if ((utilityLayers & UtilityConnectLayers) == Layer.None) return false;
+            if (!anyLayer && (utilityLayers & UtilityConnectLayers) == Layer.None) return false;
 
             float surface = SurfaceHeightAt(sourcePoint, sourceElevation.x,
                 NetInfoOf(prefab).ElevationLimit, ref heightData, ref waterData);

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/MixedOperation.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/MixedOperation.cs
@@ -120,10 +120,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             string failure = null;
             bool deterministicFailure = false;
             bool definitionsArmed = false;
-            long pendingDeadline;
-            bool allowMergedNodeSplit =
-                _nativeOperationDeadlines.TryGetValue(key, out pendingDeadline) &&
-                now >= pendingDeadline;
+            bool allowMergedNodeSplit = RelaxedResolveAllowed(key, now);
 
             try
             {
@@ -168,7 +165,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                     }
                 }
 
-                _nativeOperationDeadlines.Remove(key);
+                ClearOperationHold(key, UnresolvedMixedTargetReason,
+                    MixedOperationSubject(operation.OperationId, key.Origin),
+                    "the whole mixed operation preflighted on a later attempt");
                 _armedNetOperations.Remember(key, now, ArmedOperationWindowMs);
                 definitionsArmed = BuildAndArmMixedOperation(source, operation, key, now,
                     ref nodes, ref edges, ref ownedNodes, ref ownedEdges,
@@ -735,28 +734,40 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             NetToolOperationCommand operation, NetOperationKey key, long now,
             string reason, bool deterministic)
         {
+            int windows = 0;
             if (!deterministic)
             {
-                long deadline;
-                if (!_nativeOperationDeadlines.TryGetValue(key, out deadline))
+                if (HoldUnresolvedOperation(key, now, operation.OperationId, reason, out windows))
                 {
-                    deadline = now + NativeTargetRetryWindowMs;
-                    _nativeOperationDeadlines[key] = deadline;
-                }
-                if (now < deadline)
-                {
-                    RequeueAtFront(new List<SimulationCommandMessage>(1) { source });
+                    // Behind other senders' work, not in front of it - see RequeueStalledOperation.
+                    RequeueStalledOperation(new List<SimulationCommandMessage>(1) { source });
                     return;
                 }
             }
 
-            _nativeOperationDeadlines.Remove(key);
-            Mod.log.Warn("[MP] NetSync: mixed operation " + operation.OperationId +
-                         " cannot be preflighted atomically (" + reason +
-                         "); rejecting the whole operation and requesting world recovery.");
+            Diagnostics.ResyncReport report = Diagnostics.ResyncReport
+                .Create(UnresolvedMixedTargetReason, "net",
+                    deterministic
+                        ? Diagnostics.ResyncEvidence.Contradiction
+                        : Diagnostics.ResyncEvidence.MissingTarget)
+                .About(MixedOperationSubject(operation.OperationId, key.Origin))
+                .Tried(deterministic
+                    ? "nothing - this rejection cannot change on a retry"
+                    : "re-preflighted the whole operation every frame for " +
+                      (NativeTargetRetryWindowMs / 1000) + " s across " + windows + " window(s)")
+                .Fact("what could not be preflighted", reason)
+                .Fact("items in the operation", operation.Items != null ? operation.Items.Length : 0);
+
+            if (SyncInbox.Settle(report) == Diagnostics.ResyncVerdict.Held)
+            {
+                ExtendUnresolvedOperation(key, now);
+                RequeueStalledOperation(new List<SimulationCommandMessage>(1) { source });
+                return;
+            }
+
+            _nativeOperationHolds.Remove(key);
             Diagnostics.FlightRecorder.Note("net mixed operation rejected/resync op=" +
                                               operation.OperationId);
-            SyncInbox.RequestResync("mixed net operation target did not resolve");
         }
 
         private static Dictionary<int, List<MixedDeleteAction>> GroupMixedDeletes(

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/MixedOperation.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/MixedOperation.cs
@@ -720,7 +720,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                 Diagnostics.FlightRecorder.Note((commitArmed ?
                     "net mixed operation post-arm failure/resync op=" :
                     "net mixed operation rollback/resync op=") + operation.OperationId);
-                SyncInbox.RequestResync("mixed net operation could not be generated atomically");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("mixed net operation could not be generated atomically", "net",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("mixed operation generation")
+                    .Tried("nothing - the operation threw while being generated and cannot be rebuilt identically"));
                 return commitArmed;
             }
             finally

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/NetSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/NetSyncSystem.cs
@@ -257,6 +257,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
         // Consecutive ToolUpdate observations with none of the committed graph still Temp. Native
         // cleanup is deferred, so the next transaction stays blocked through a short clean fence.
         private int _drainCleanFrames;
+
+        /// <summary>Fewest surviving Temps this drain has observed; a new low restarts its window.</summary>
+        private int _drainRemainingTemps = int.MaxValue;
         // Remains set through the ToolUpdate which releases either drain state. Systems after
         // NetSync in that phase must still observe the coordinator as busy.
         private bool _drainReleasedThisFrame;
@@ -713,7 +716,10 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             _atomicMixedOriginalsFrame = -1;
             _nativeTargetDeadlines.Clear();
             _operationAssemblyDeadlines.Clear();
-            _nativeOperationDeadlines.Clear();
+            _nativeOperationHolds.Clear();
+            // The world these described is being replaced; nothing left to withdraw or settle.
+            _outstandingDrainSubjects.Clear();
+            _drainRemainingTemps = int.MaxValue;
             _operationBuildFailures.Clear();
             _completedNetOperations.Clear();
             _armedNetOperations.Clear();
@@ -809,7 +815,13 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                 {
                     Mod.log.Warn("[MP] NetSync: mixed-operation inbox admission cap reached; " +
                                  "requesting recovery instead of dropping an atomic edit silently.");
-                    SyncInbox.RequestResync("mixed net operation inbox overflow");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("mixed net operation inbox overflow", "net",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                        .About("mixed net inbox")
+                        .Tried("nothing - the edit was refused at the door rather than dropped silently")
+                        .Fact("queued mixed operations", _sink.Count)
+                        .Fact("admission cap", MixedNetInboxAdmissionCap));
                     return;
                 }
                 // Remote Temp work intentionally waits while a local interactive tool is active.

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Realize.cs
@@ -43,8 +43,25 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
 
         private readonly Dictionary<NetOperationKey, long> _operationAssemblyDeadlines =
             new Dictionary<NetOperationKey, long>();
-        private readonly Dictionary<NetOperationKey, long> _nativeOperationDeadlines =
-            new Dictionary<NetOperationKey, long>();
+
+        /// <summary>
+        /// What an operation whose target has not appeared is still waiting for.
+        ///
+        /// <see cref="NativeOperationHold.Relaxed"/> is separate from the deadline on purpose. The
+        /// resolver's last-resort matches unlock when the first window expires, and a second window
+        /// granted by the resync arbiter must not take them away again - re-deriving "relaxed" from
+        /// the deadline alone would do exactly that, and the operation would spend its extra window
+        /// with strictly less resolving power than the one before it.
+        /// </summary>
+        private struct NativeOperationHold
+        {
+            public long DeadlineMs;
+            public bool Relaxed;
+            public int Windows;
+        }
+
+        private readonly Dictionary<NetOperationKey, NativeOperationHold> _nativeOperationHolds =
+            new Dictionary<NetOperationKey, NativeOperationHold>();
         private readonly Dictionary<NetOperationKey, int> _operationBuildFailures =
             new Dictionary<NetOperationKey, int>();
 
@@ -247,10 +264,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                     bool aliasedSplitTarget = false;
                     int alreadyBuiltCourses = 0;
                     string unresolvedDetail = null;
-                    long pendingDeadline;
-                    allowMergedNodeSplit =
-                        _nativeOperationDeadlines.TryGetValue(operationRetryKey, out pendingDeadline) &&
-                        now >= pendingDeadline;
+                    NetPlacementCommand unresolvedCommand = null;
+                    bool unresolvedStartResolved = false;
+                    allowMergedNodeSplit = RelaxedResolveAllowed(operationRetryKey, now);
                     _batchSplitClaims.Clear();
 
                     for (int i = 0; i < work.Count; i++)
@@ -324,7 +340,12 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                         {
                             Mod.log.Warn("[MP] NetSync: native operation " + command.OperationId +
                                          " contains an unsafe creation mode; dropping the whole operation.");
-                            SyncInbox.RequestResync("unsafe native net creation flags");
+                            SyncInbox.RequestResync(Diagnostics.ResyncReport
+                                .Create("unsafe native net creation flags", "net",
+                                    Diagnostics.ResyncEvidence.StreamLoss)
+                                .About("op " + command.OperationId)
+                                .Tried("nothing - the operation was refused before it could be built")
+                                .Fact("creation flags on the wire", command.CreationFlags));
                             return;
                         }
                         // NetCourse elevations are exact native generator state, not values limited
@@ -399,7 +420,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                         {
                             unresolvedOperationTarget = true;
                             if (unresolvedDetail == null)
+                            {
                                 unresolvedDetail = DescribeUnresolvedEndpoint(command, startResolved);
+                                unresolvedCommand = command;
+                                unresolvedStartResolved = startResolved;
+                            }
                         }
 
                         if (geometryAlreadyBuilt && topologyNeedsReplay)
@@ -414,7 +439,10 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
 
                     if (alreadyBuiltCourses == work.Count)
                     {
-                        _nativeOperationDeadlines.Remove(operationRetryKey);
+                        ClearOperationHold(operationRetryKey, UnresolvedNativeTargetReason,
+                            NativeOperationSubject(operationHeader.OperationId,
+                                operationRetryKey.Origin),
+                            "the operation turned out to be already present");
                         _operationBuildFailures.Remove(operationRetryKey);
                         Diagnostics.FlightRecorder.Note("net native op already present=" +
                                                           operationHeader.OperationId +
@@ -428,36 +456,65 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
 
                     if (unresolvedOperationTarget)
                     {
-                        long deadline;
-                        if (!_nativeOperationDeadlines.TryGetValue(operationRetryKey, out deadline))
+                        int windows;
+                        if (HoldUnresolvedOperation(operationRetryKey, now,
+                                operationHeader.OperationId, unresolvedDetail, out windows))
                         {
-                            deadline = now + NativeTargetRetryWindowMs;
-                            _nativeOperationDeadlines[operationRetryKey] = deadline;
-                            Diagnostics.FlightRecorder.Note("net native target retry op=" +
-                                                              operationHeader.OperationId + " " +
-                                                              unresolvedDetail);
-                        }
-                        if (now < deadline)
-                        {
-                            RequeueAtFront(work);
+                            // Wait BEHIND work that can still make progress, not in front of it.
+                            // Parking the whole queue here for the length of the window stopped
+                            // every later operation from every player - including, in the logs this
+                            // came from, the ones that would have built the target being waited for.
+                            RequeueStalledOperation(work);
                             return;
                         }
 
-                        _nativeOperationDeadlines.Remove(operationRetryKey);
-                        Mod.log.Warn("[MP] NetSync: native operation " + operationHeader.OperationId +
-                                     " has an unresolved target after its retry window (" +
-                                     unresolvedDetail + "); rejecting the complete operation and " +
-                                     "requesting world recovery.");
+                        // The window is up. Before spending a world reload on it, say exactly what
+                        // is missing and what stands there instead, and let the arbiter decide: the
+                        // same "missing" road has been observed to be one this machine's own delete
+                        // feeder removed while the placement waited.
+                        // Non-null whenever unresolvedOperationTarget is set - they are assigned
+                        // together - but the endpoint description is worth having either way.
+                        NetEndpointIntent failedEndpoint = unresolvedCommand == null
+                            ? default(NetEndpointIntent)
+                            : unresolvedStartResolved ? unresolvedCommand.End : unresolvedCommand.Start;
+                        Diagnostics.ResyncReport report = Diagnostics.ResyncReport
+                            .Create(UnresolvedNativeTargetReason, "net",
+                                Diagnostics.ResyncEvidence.MissingTarget)
+                            .About(NativeOperationSubject(operationHeader.OperationId,
+                                operationRetryKey.Origin))
+                            .Tried("re-resolved the endpoint every frame for " +
+                                   (NativeTargetRetryWindowMs / 1000) + " s across " + windows +
+                                   " window(s), including the relaxed node/edge fallbacks")
+                            .Fact("the other player built", operationHeader.PrefabName)
+                            .Fact("courses in the operation", work.Count)
+                            .Fact("courses already present here", alreadyBuiltCourses)
+                            .Fact("endpoint that would not resolve", unresolvedDetail)
+                            .Fact("what is actually here",
+                                DescribeLocalAnchorNeighbourhood(failedEndpoint, ref nodes, ref edges))
+                            .Fact("net operations still queued", _remoteDeferred.Count + _incoming.Count);
+
+                        if (SyncInbox.Settle(report) == Diagnostics.ResyncVerdict.Held)
+                        {
+                            // Not settled: keep the edit. The arbiter has frozen the feeders that
+                            // could remove the target, so this window is the first one that gets to
+                            // look at a world that is standing still.
+                            ExtendUnresolvedOperation(operationRetryKey, now);
+                            RequeueStalledOperation(work);
+                            return;
+                        }
+
+                        _nativeOperationHolds.Remove(operationRetryKey);
                         Diagnostics.FlightRecorder.Note("net native operation rejected/resync op=" +
                                                           operationHeader.OperationId + " " +
                                                           unresolvedDetail);
-                        SyncInbox.RequestResync("native net target did not resolve");
                         return;
                     }
                     if (allowMergedNodeSplit)
                         Diagnostics.FlightRecorder.Note("net native node target recovered op=" +
                                                           operationHeader.OperationId);
-                    _nativeOperationDeadlines.Remove(operationRetryKey);
+                    ClearOperationHold(operationRetryKey, UnresolvedNativeTargetReason,
+                        NativeOperationSubject(operationHeader.OperationId, operationRetryKey.Origin),
+                        "every endpoint resolved on a later attempt");
 
                     // Every target resolved, but two of them collapsed onto one local edge. There is
                     // no safe way to commit that batch and no way to repair it from here: the missing
@@ -465,14 +522,21 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                     if (aliasedSplitTarget)
                     {
                         _operationBuildFailures.Remove(operationRetryKey);
-                        Mod.log.Warn("[MP] NetSync: native operation " + operationHeader.OperationId +
-                                     " resolved two different source edges onto one local edge - this " +
-                                     "machine is missing an earlier split. Requesting world recovery " +
-                                     "rather than committing an aliased batch.");
                         Diagnostics.FlightRecorder.Note("net native op aliased split target op=" +
                                                           operationHeader.OperationId +
                                                           " courses=" + work.Count);
-                        SyncInbox.RequestResync("net split target aliased by local divergence");
+                        SyncInbox.RequestResync(Diagnostics.ResyncReport
+                            .Create("net split target aliased by local divergence", "net",
+                                Diagnostics.ResyncEvidence.Contradiction)
+                            .About("op " + operationHeader.OperationId + " from player " +
+                                   work[0].OriginPlayerId)
+                            .Tried("nothing - committing the batch anyway would hand the game two " +
+                                   "junctions cut from one road, which it dereferences without a check")
+                            .Fact("what disagrees",
+                                "two roads the other player split separately are one road here, so " +
+                                "an earlier split never arrived")
+                            .Fact("the other player built", operationHeader.PrefabName)
+                            .Fact("courses in the operation", work.Count));
                         return;
                     }
 
@@ -985,7 +1049,12 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                         {
                             Mod.log.Warn("[MP] NetSync: dropping malformed mixed net operation: " +
                                          ex.Message);
-                            SyncInbox.RequestResync("malformed mixed net operation");
+                            SyncInbox.RequestResync(Diagnostics.ResyncReport
+                                .Create("malformed mixed net operation", "net",
+                                    Diagnostics.ResyncEvidence.StreamLoss)
+                                .About("mixed operation from player " + message.OriginPlayerId)
+                                .Tried("nothing - the operation could not be decoded")
+                                .Fact("decoder said", ex.Message));
                             return false;
                         }
                         operation = new List<SimulationCommandMessage>(1) { message };
@@ -1075,11 +1144,15 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                         later.Add(scanned[i]);
                 }
                 RequeueAtFront(later);
-                Mod.log.Warn("[MP] NetSync: incomplete operation " + key.Operation + " from player " +
-                             key.Origin + " expired (" + received + "/" + expected + "); dropped whole operation.");
                 Diagnostics.FlightRecorder.Note("net incomplete op dropped=" + key.Operation +
                     " courses=" + received + "/" + expected);
-                SyncInbox.RequestResync("incomplete net operation expired");
+                SyncInbox.RequestResync(Diagnostics.ResyncReport
+                    .Create("incomplete net operation expired", "net",
+                        Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("op " + key.Operation + " from player " + key.Origin)
+                    .Tried("waited " + (OperationAssemblyWindowMs / 1000) +
+                           " s for the missing pieces of the road the other player drew")
+                    .Fact("pieces received", received + " of " + expected));
                 return false;
             }
 
@@ -1120,11 +1193,15 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             // from smuggling a partially native operation into per-course fallback realization.
             if ((hasNativeCourse && hasGeometryOnlyCourse) || (expected > 1 && !nativeOperation))
             {
-                Mod.log.Warn("[MP] NetSync: operation " + key.Operation + " from player " +
-                             key.Origin + " mixed incompatible course encodings; dropped whole operation.");
                 Diagnostics.FlightRecorder.Note("net incompatible multi-course op dropped=" +
                                                   key.Operation);
-                SyncInbox.RequestResync("incompatible net operation rejected");
+                SyncInbox.RequestResync(Diagnostics.ResyncReport
+                    .Create("incompatible net operation rejected", "net",
+                        Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("op " + key.Operation + " from player " + key.Origin)
+                    .Tried("nothing - the operation mixed two course encodings that cannot be " +
+                           "applied as one transaction")
+                    .Fact("courses in the operation", expected));
                 operation = null;
                 nativeOperation = false;
                 return false;
@@ -1152,6 +1229,214 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
         {
             if (messages != null && messages.Count > 0)
                 _remoteDeferred.InsertRange(0, messages);
+        }
+
+        /// <summary>
+        /// Re-queue an operation that is waiting for a target it cannot see yet, WITHOUT parking
+        /// the rest of the pipeline behind it.
+        ///
+        /// The queue is strictly ordered, so the previous behaviour - putting it straight back at
+        /// the front - stopped every later operation, from every player, for the whole retry
+        /// window. That is worse than a delay: in the sessions this came from, the deferred
+        /// placement spent ten seconds in front of a queue while the world it was searching went on
+        /// changing, and then asked for a full world reload because what it was looking for was no
+        /// longer there.
+        ///
+        /// Causal order was only ever meaningful per sender, so only ANOTHER sender's work may
+        /// overtake. Everything the same sender queued behind this operation stays behind it.
+        /// </summary>
+        private void RequeueStalledOperation(List<SimulationCommandMessage> messages)
+        {
+            if (messages == null || messages.Count == 0) return;
+            int origin = messages[0].OriginPlayerId;
+
+            // Admit what has arrived so the reorder sees the whole ready set rather than whatever a
+            // previous scan happened to leave behind. Realization stays gated where it always was
+            // (see TryTakeNextPlacementMessage); only where the messages sit changes, and the same
+            // inbox cap bounds it.
+            SimulationCommandMessage admitted;
+            while (_remoteDeferred.Count < NetInboxCap && _incoming.TryDequeue(out admitted))
+                _remoteDeferred.Add(admitted);
+
+            int insertAt = 0;
+            while (insertAt < _remoteDeferred.Count &&
+                   _remoteDeferred[insertAt].OriginPlayerId != origin) insertAt++;
+            _remoteDeferred.InsertRange(insertAt, messages);
+        }
+
+        /// <summary>
+        /// A hold whose window lapsed this long ago no longer counts. An operation can leave the
+        /// pipeline by other doors - duplicate suppression, a malformed decode - and a forgotten
+        /// hold must never be able to stop bulldozing for the rest of a session.
+        /// </summary>
+        private const long StaleHoldGraceMs = 2000;
+
+        /// <summary>
+        /// True while at least one native operation is inside a live window waiting for a target
+        /// that has not arrived, pruning any hold whose window has fully lapsed.
+        ///
+        /// The feeders that can only ever REMOVE such a target - bulldoze, road replacement - stand
+        /// down while this is true. They used to run ahead of it every frame, which is how a
+        /// placement came to be rejected for a road this machine had just deleted out from under
+        /// it. Two windows is the most any operation gets, so the hold is seconds, not minutes.
+        /// </summary>
+        public bool HasStalledNativeOperation(long now)
+        {
+            if (_nativeOperationHolds.Count == 0) return false;
+            List<NetOperationKey> stale = null;
+            bool live = false;
+            foreach (KeyValuePair<NetOperationKey, NativeOperationHold> entry in _nativeOperationHolds)
+            {
+                if (now < entry.Value.DeadlineMs + StaleHoldGraceMs) { live = true; continue; }
+                (stale ?? (stale = new List<NetOperationKey>())).Add(entry.Key);
+            }
+            if (stale != null)
+                for (int i = 0; i < stale.Count; i++) _nativeOperationHolds.Remove(stale[i]);
+            return live;
+        }
+
+        /// <summary>
+        /// Whether the resolver may use its relaxed last-resort matches for this operation - the
+        /// merged-node-as-edge-split fallback. Unlocked once a full retry window has passed, and
+        /// never locked again for that operation (see <see cref="NativeOperationHold"/>).
+        /// </summary>
+        private bool RelaxedResolveAllowed(NetOperationKey key, long now)
+        {
+            NativeOperationHold hold;
+            if (!_nativeOperationHolds.TryGetValue(key, out hold)) return false;
+            return hold.Relaxed || now >= hold.DeadlineMs;
+        }
+
+        /// <summary>
+        /// Arm or advance the hold on an operation whose target is missing. Returns true while it
+        /// should keep waiting; false once the current window is up and a verdict is due.
+        /// </summary>
+        private bool HoldUnresolvedOperation(NetOperationKey key, long now, long operationId,
+            string detail, out int windows)
+        {
+            NativeOperationHold hold;
+            if (!_nativeOperationHolds.TryGetValue(key, out hold))
+            {
+                hold = new NativeOperationHold
+                {
+                    DeadlineMs = now + NativeTargetRetryWindowMs,
+                    Relaxed = false,
+                    Windows = 1,
+                };
+                _nativeOperationHolds[key] = hold;
+                Diagnostics.FlightRecorder.Note("net native target retry op=" + operationId +
+                                                  " " + detail);
+            }
+            windows = hold.Windows;
+            return now < hold.DeadlineMs;
+        }
+
+        /// <summary>
+        /// Grant one more window after the arbiter declined to settle the report. Deliberately
+        /// shorter than the first: this one runs against a world the arbiter has frozen, so it is a
+        /// far better test than the first window was, and the feeders it holds up are waiting on it.
+        /// </summary>
+        private void ExtendUnresolvedOperation(NetOperationKey key, long now)
+        {
+            NativeOperationHold hold;
+            _nativeOperationHolds.TryGetValue(key, out hold);
+            hold.DeadlineMs = now + NativeTargetRetryWindowMs / 2;
+            hold.Relaxed = true;
+            hold.Windows++;
+            _nativeOperationHolds[key] = hold;
+        }
+
+        /// <summary>How a report and a withdrawal name the same stalled operation.</summary>
+        internal const string UnresolvedNativeTargetReason = "native net target did not resolve";
+        internal const string UnresolvedMixedTargetReason = "mixed net operation target did not resolve";
+
+        private static string NativeOperationSubject(long operationId, int origin) =>
+            "op " + operationId + " from player " + origin;
+
+        private static string MixedOperationSubject(long operationId, int origin) =>
+            "mixed op " + operationId + " from player " + origin;
+
+        /// <summary>
+        /// Release a hold because the operation succeeded. Withdrawing the report is the point of
+        /// holding one: a world reload that was proposed and then did not have to happen is worth
+        /// exactly as much in the log as one that did.
+        /// </summary>
+        private void ClearOperationHold(NetOperationKey key, string reason, string subject,
+            string outcome)
+        {
+            if (!_nativeOperationHolds.Remove(key)) return;
+            Diagnostics.ResyncArbiter.Withdraw("net", reason, subject,
+                Mod.Service != null ? Mod.Service.NowMs : 0L, outcome);
+        }
+
+        /// <summary>
+        /// What this machine actually has where the source anchored its endpoint, and why each
+        /// candidate was refused.
+        ///
+        /// This is the fact the log never carried. "No road within reach", "a Medium Road is there
+        /// instead of the Small Road named", and "the road is there but six metres lower" are three
+        /// entirely different bugs, and all three used to print the same line before reloading the
+        /// world. Runs once, on the frame a reload is being considered, so the wider search it does
+        /// costs nothing in the normal case.
+        /// </summary>
+        private string DescribeLocalAnchorNeighbourhood(NetEndpointIntent intent,
+            ref NodePool nodes, ref EdgePool edges)
+        {
+            const float SearchXZ = 16f;
+            float3 anchor = new float3(intent.AnchorX, intent.AnchorY, intent.AnchorZ);
+            var report = new System.Text.StringBuilder();
+
+            float bestNodeXZ = float.MaxValue, bestNodeDy = 0f;
+            NetCellIndex.Enumerator nodeCandidates = nodes.Index.Near(anchor.xz, SearchXZ);
+            while (nodeCandidates.MoveNext())
+            {
+                int i = nodeCandidates.Current;
+                float xz = math.distance(nodes.Data[i].m_Position.xz, anchor.xz);
+                if (xz >= bestNodeXZ) continue;
+                bestNodeXZ = xz;
+                bestNodeDy = nodes.Data[i].m_Position.y - anchor.y;
+            }
+
+            float bestEdgeXZ = float.MaxValue, bestEdgeDy = 0f;
+            string bestEdgePrefab = null;
+            NetCellIndex.Enumerator edgeCandidates = edges.Index.Near(anchor.xz, SearchXZ);
+            while (edgeCandidates.MoveNext())
+            {
+                int i = edgeCandidates.Current;
+                float t;
+                float xz = MathUtils.Distance(edges.Curves[i].m_Bezier.xz, anchor.xz, out t);
+                if (xz >= bestEdgeXZ) continue;
+                Entity edge = edges.Entities[i];
+                if (!EntityManager.Exists(edge)) continue;
+                bestEdgeXZ = xz;
+                bestEdgeDy = MathUtils.Position(edges.Curves[i].m_Bezier, t).y - anchor.y;
+                bestEdgePrefab = EntityManager.HasComponent<global::Game.Prefabs.PrefabRef>(edge)
+                    ? PrefabNameOf(EntityManager
+                        .GetComponentData<global::Game.Prefabs.PrefabRef>(edge).m_Prefab)
+                    : "(no prefab)";
+            }
+
+            if (bestEdgeXZ == float.MaxValue)
+            {
+                report.Append("no road at all within ").Append(SearchXZ.ToString("F0")).Append(" m");
+            }
+            else
+            {
+                report.Append("nearest road is '").Append(bestEdgePrefab).Append("' ")
+                    .Append(bestEdgeXZ.ToString("F1")).Append(" m away, ")
+                    .Append(bestEdgeDy.ToString("F1")).Append(" m in height");
+            }
+
+            if (bestNodeXZ != float.MaxValue)
+                report.Append("; nearest junction ").Append(bestNodeXZ.ToString("F1"))
+                    .Append(" m away, ").Append(bestNodeDy.ToString("F1")).Append(" m in height");
+
+            // The resolver's own tolerances, so a reader can see at a glance whether the candidate
+            // above was refused on distance or on identity.
+            report.Append(" (must be within ").Append(NativeEdgeResolveXZ.ToString("F0"))
+                .Append(" m and ").Append(NativeTargetResolveY.ToString("F0"))
+                .Append(" m of height, same prefab, same layers, same owner)");
+            return report.ToString();
         }
 
         private static NativeTargetRetryKey NativeRetryKey(SimulationCommandMessage message,
@@ -1341,8 +1626,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             if (kind != KindFree) return result;
 
             float3 projected;
-            if (!TryProjectUtilityEndpointToLocalSurface(prefab, placedInfo, sourcePoint,
-                    sourceElevation, ref heightData, ref waterData, out projected))
+            // Utility layers only here: this path classifies an endpoint the source left on open
+            // ground, where a height reference moved for a road is exactly the bridge/tunnel level
+            // separation that must be preserved.
+            if (!TryProjectEndpointToLocalSurface(prefab, placedInfo, sourcePoint,
+                    sourceElevation, false, ref heightData, ref waterData, out projected))
                 return result;
 
             float projectedT;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/Realize.cs
@@ -837,7 +837,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
                     // Aliasing is deterministic: retrying the same courses against the same local
                     // geometry resolves them onto the same edge again. Recover the world instead.
                     bool retry = failures <= 3 && !abortAliasedSplit;
-                    if (abortAliasedSplit) SyncInbox.RequestResync("net split target aliased by local divergence");
+                    if (abortAliasedSplit) SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("net split target aliased by local divergence", "net",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("aliased split target")
+                        .Tried("nothing - two roads the other player split separately are one road here"));
                     if (retry)
                     {
                         _operationBuildFailures[failureKey] = failures;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/ResolveIntent.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Nets/NetSyncSystem/ResolveIntent.cs
@@ -76,11 +76,16 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
         }
 
         /// <summary>
-        /// Resolve a captured target at its source-world height, then (for owner-less utility
-        /// nodes/edges only) at the corresponding local-surface height. Explicit target identity,
-        /// prefab/layer contracts and curve direction are still required by the second pass; only
-        /// the Y reference changes. This prevents terrain/water drift from turning a valid captured
-        /// pipe or cable snap into an unresolved operation.
+        /// Resolve a captured target at its source-world height, then at the corresponding
+        /// local-surface height. Explicit target identity, prefab/layer contracts and curve
+        /// direction are still required by the second pass; only the Y reference changes. This
+        /// prevents terrain/water drift from turning a valid captured snap into an unresolved
+        /// operation.
+        ///
+        /// Normally the second pass covers utility nets only. Once an operation has spent a full
+        /// retry window (<paramref name="allowMergedNodeSplit"/>, which is what marks the
+        /// last-resort pass), it covers roads and rails too - see
+        /// <see cref="TryProjectEndpointToLocalSurface"/> for why that gap mattered.
         /// </summary>
         private bool TryResolveNativeEndpointWithLocalSurface(Entity prefab,
             NetEndpointIntent intent, NetPrefabInfo placedInfo,
@@ -103,8 +108,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems.Net
             float3 sourcePoint = new float3(intent.PosX, intent.PosY, intent.PosZ);
             float2 sourceElevation = new float2(intent.ElevationLeft, intent.ElevationRight);
             float3 projected;
-            if (!TryProjectUtilityEndpointToLocalSurface(prefab, placedInfo, sourcePoint,
-                    sourceElevation, ref heightData, ref waterData, out projected))
+            if (!TryProjectEndpointToLocalSurface(prefab, placedInfo, sourcePoint,
+                    sourceElevation, allowMergedNodeSplit, ref heightData, ref waterData,
+                    out projected))
                 return false;
 
             float deltaY = projected.y - intent.PosY;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/NativeRealize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/NativeRealize.cs
@@ -255,13 +255,21 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     Diagnostics.FlightRecorder.Note(
                         "object operation target expired; world sync requested");
                 }
+                // Read before the reset below clears it - it is the whole point of the report.
+                string unresolvedDetail = _lastUnresolvedObjectReason ?? "unknown target";
                 _hasBlockedNativeObject = false;
                 _blockedNativeObject = null;
                 _blockedNativeObjectDeadline = 0;
                 _lastUnresolvedObjectReason = null;
-                SyncInbox.RequestResync(compactPlacement
-                    ? "building placement target did not resolve"
-                    : "native object operation target did not resolve");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create(compactPlacement
+                            ? "building placement target did not resolve"
+                            : "native object operation target did not resolve",
+                        "object", CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                    .About(compactPlacement ? "building placement target" : "native object target")
+                    .Tried("re-resolved the target every frame for the whole retry window, not " +
+                           "counting time the road pipeline was held back")
+                    .Fact("what would not resolve", unresolvedDetail));
                 return false;
             }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/NativeRealize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/NativeRealize.cs
@@ -381,11 +381,19 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                  "the remote stamp '" + prefabName +
                                  "' was skipped and world recovery was requested.");
                     Diagnostics.FlightRecorder.Note("asset stamp unsupported; recovery requested");
-                    SyncInbox.RequestResync("asset stamp generator unavailable");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("asset stamp generator unavailable", "object",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("asset stamp generator")
+                        .Tried("nothing - this build cannot reach the generator and a stamp has no reduced form"));
                     return NativeObjectResult.Rejected;
                 case NativeDeriveResult.Failed:
                     Diagnostics.FlightRecorder.Note("asset stamp derive failed; recovery requested");
-                    SyncInbox.RequestResync("asset stamp generation failed");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("asset stamp generation failed", "object",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("asset stamp generation")
+                        .Tried("nothing - the generator refused the stamp and will refuse it again"));
                     return NativeObjectResult.Rejected;
                 default:
                     return NativeObjectResult.Rejected;
@@ -507,7 +515,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                              "requesting world recovery: " + ex.Message);
                 Diagnostics.FlightRecorder.Note("object definitions failed=" + ex.GetType().Name +
                                                   "; recovery requested");
-                SyncInbox.RequestResync("native object definitions could not be generated");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("native object definitions could not be generated", "object",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("object definition generation")
+                    .Tried("tore the partial definitions down, so nothing inconsistent was committed"));
                 return NativeObjectResult.Rejected;
             }
 
@@ -1071,7 +1083,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 Mod.log.Warn("[MP] BuildSync: native object replay prefix overflowed; requesting " +
                              "world recovery instead of losing an operation.");
                 Diagnostics.FlightRecorder.Note("object replay prefix overflow; recovery requested");
-                SyncInbox.RequestResync("native object replay prefix overflow");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("native object replay prefix overflow", "object",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("object replay prefix")
+                    .Tried("nothing - the replay prefix was full and the operation could not be kept"));
                 return;
             }
             _nativeObjectReplayPrefix.Add(message);

--- a/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Objects/BuildSyncSystem/Realize.cs
@@ -51,10 +51,28 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         private NativeArray<PrefabRef> _dupPrefabs;
         private bool _dupSnapshotTaken;
 
+        private readonly HeldTime _targetHold = new HeldTime();
+
         private void RealizeIncoming(MultiplayerSession session, long now)
         {
             if (_incoming.IsEmpty && _nativeObjectReplayPrefix.Count == 0 &&
                 _attachRetry.Count == 0 && !_hasBlockedNativeObject) return;
+
+            // What these windows wait for is a ROAD - the attachment parent below says so in as
+            // many words - and roads are exactly what the realize pipeline holds back while
+            // terrain or the net commit catches up. Spending the window during that hold expires
+            // it against a parent that could not have arrived, and the expiry asks for a full
+            // world reload. Below, the same three conditions skip the attempt entirely.
+            long heldMs = _targetHold.Observe(now,
+                RealizeGate.WorldBuildingHeld || DeferForTerrain ||
+                _nativeNetCoordinator.IsCommitBusy);
+            if (heldMs > 0)
+            {
+                for (int h = 0; h < _attachRetry.Count; h++)
+                    _attachRetry[h] = (_attachRetry[h].command, _attachRetry[h].prefab,
+                        _attachRetry[h].originPlayerId, _attachRetry[h].deadline + heldMs);
+                if (_hasBlockedNativeObject) _blockedNativeObjectDeadline += heldMs;
+            }
 
             PruneNativeObjectOperations(now);
             if (_nativeNetCoordinator.IsCommitBusy) return;
@@ -146,7 +164,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     Mod.log.Warn("[MP] BuildSync realize: reduced placement for spatial object '" +
                                  command.PrefabName +
                                  "' was rejected; requesting world recovery.");
-                    SyncInbox.RequestResync("reduced spatial object placement rejected");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("reduced spatial object placement rejected", "object",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("reduced spatial placement")
+                        .Tried("nothing - the reduced form of this placement cannot be committed here"));
                     continue;
                 }
 
@@ -161,7 +183,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                      "incomplete backlog and requesting world recovery.");
                         Diagnostics.FlightRecorder.Note(
                             "attachment retry queue overflow; recovery requested");
-                        SyncInbox.RequestResync("object attachment retry queue overflow");
+                        SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                            .Create("object attachment retry queue overflow", "object",
+                                CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                            .About("attachment retry queue")
+                            .Tried("nothing - the queue was full and was cleared"));
                         return;
                     }
                     _attachRetry.Add((command, prefab, message.OriginPlayerId, now + AttachRetryWindowMs));
@@ -206,7 +232,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                  " s; requesting world recovery.");
                     Diagnostics.FlightRecorder.Note(
                         "attachment target expired; recovery requested");
-                    SyncInbox.RequestResync("object attachment target did not resolve");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("object attachment target did not resolve", "object",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                        .About("attachment parent road")
+                        .Tried("waited 10 s of attempts for the parent road, not counting time the road pipeline was held"));
                 }
             }
         }
@@ -248,7 +278,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 Mod.log.Error("[MP] BuildSync realize FAILED for '" + command.PrefabName + "': " + ex);
                 Diagnostics.FlightRecorder.Note("build realize FAILED '" + command.PrefabName + "': "
                     + ex.GetType().Name + "; recovery requested");
-                SyncInbox.RequestResync("object placement realization failed");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("object placement realization failed", "object",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("object placement")
+                    .Tried("nothing - realization threw and the placement was rolled back"));
             }
         }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
@@ -46,6 +46,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         }
 
         private bool _wasDeferringTerrain;
+        private bool _wasHoldingNetMutations;
 
         private const int FaultReportThrottleMs = 10000;
         private readonly Dictionary<string, int> _lastFaultTick = new Dictionary<string, int>();
@@ -114,15 +115,35 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 }
 
                 Step("BuildSync", _buildSync.RealizePending);
+                // A remote placement that is still waiting for the road it anchors to must not be
+                // overtaken by work that can only take that road away. Delete and replace live in
+                // their own feeders, so wire order between them and a deferred placement was never
+                // enforced: in the sessions this came from, two bulldozes were applied during the
+                // ten seconds a placement spent waiting, and the placement then asked for a full
+                // world reload because its target was "missing". Bounded by the placement's own
+                // retry window, and a delete can never be what a placement is waiting for, so
+                // holding it cannot deadlock.
+                long nowMs = Mod.Service != null ? Mod.Service.NowMs : 0L;
+                bool netMutationHeld = _netSync.HasStalledNativeOperation(nowMs) ||
+                    CS2MultiplayerMod.Game.Diagnostics.ResyncArbiter.NetMutationFrozen(nowMs);
+                if (netMutationHeld != _wasHoldingNetMutations)
+                {
+                    _wasHoldingNetMutations = netMutationHeld;
+                    CS2MultiplayerMod.Game.Diagnostics.FlightRecorder.Note(netMutationHeld
+                        ? "net delete/replace held behind a stalled placement"
+                        : "net delete/replace resumed");
+                }
                 // DeleteSync BEFORE NetSync: a remote bulldoze applied this frame tags its edge Deleted,
                 // and NetSync's split-target query excludes Deleted edges — so NetSync never resolves a
                 // split onto an edge that is being removed this same frame (a stale-reference crash in
                 // ApplyNetSystem). NetSync's own commit (flipping applyMode) is independent of delete order.
+                _deleteSync.DeferNetForPendingPlacement = netMutationHeld;
                 Step("DeleteSync", _deleteSync.RealizePending);
                 // Road-type replacements also drive NetSync's single ApplyTool commit slot, so run after
                 // DeleteSync and before NetSync's build: a delete armed this frame makes replace defer
                 // (IsCommitBusy), and an armed replace makes NetSync's build defer — only one net batch
                 // enters any one ApplyTool pass, never a build+replace of the same edge together.
+                _netReplaceSync.DeferForPendingPlacement = netMutationHeld;
                 if (!deferTerrain) Step("NetReplaceSync", _netReplaceSync.RealizePending);
                 Step("NetSync", _netSync.RealizePending);
                 bool deferNetworkDependents = deferTerrain || _netSync.HasPlacementBacklog;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
@@ -147,6 +147,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 if (!deferTerrain) Step("NetReplaceSync", _netReplaceSync.RealizePending);
                 Step("NetSync", _netSync.RealizePending);
                 bool deferNetworkDependents = deferTerrain || _netSync.HasPlacementBacklog;
+                // Published for the systems that only WAIT on roads, zoning and zone-grown
+                // buildings. They are not gated themselves, so without this they keep counting down
+                // retry windows for targets this pipeline is deliberately holding back.
+                CS2MultiplayerMod.Game.Sync.Infrastructure.RealizeGate.WorldBuildingHeld =
+                    deferNetworkDependents;
                 if (!deferNetworkDependents) Step("ZoneSync", _zoneSync.RealizePending);
                 Step("TerrainSync", _terrainSync.RealizePending);
                 // After ZoneSync and behind the same network gate: a zoned building is grown on a lot

--- a/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Pipeline/SyncRealizeSystem.cs
@@ -153,13 +153,19 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 // that a road and its zoning produced, so realizing one before those arrive would put
                 // it on ground the receiver does not yet consider buildable.
                 _growableSync.DeferForTerrain = deferTerrain;
+                _growableSync.NetworkDependenciesHeld = deferNetworkDependents;
                 if (!deferNetworkDependents) Step("GrowableSync", _growableSync.RealizePending);
+                else _growableSync.NotifyRealizeHeld(nowMs);
                 Step("UpgradeSync", _upgradeSync.RealizePending);
                 Step("MoveSync", _moveSync.RealizePending);
                 if (!deferNetworkDependents) Step("NetUpgradeSync", _netUpgradeSync.RealizePending);
                 Step("AreaSync", _areaSync.RealizePending);
                 Step("RouteSync.FinalizePending", _routeSync.FinalizePending);
+                // Held rather than skipped: a route's retry window is for waiting on its own stop
+                // or road, not for waiting on permission to look, and expiring one unattempted
+                // asks for a world reload over a command that was never tried.
                 if (!deferNetworkDependents) Step("RouteSync", _routeSync.RealizePending);
+                else _routeSync.NotifyRealizeHeld(nowMs);
                 Step("TilePurchaseSync", _tileSync.RealizePending);
                 // Disaster events are plain simulation entities - no definitions, no terrain
                 // dependency - but they must still be created here: the game's event initialization

--- a/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/Realize.cs
@@ -40,7 +40,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             Entity prefab;
             if (!_prefabIndex.TryResolve(command.PrefabName, out prefab))
             {
-                SyncInbox.RequestResync("unknown route prefab during creation");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("unknown route prefab during creation", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("route prefab on creation")
+                    .Tried("nothing - this game does not have the transport line prefab the other player used"));
                 Mod.log.Warn("[MP] RouteSync create: unknown prefab '" +
                              command.PrefabName + "'; skipping.");
                 return RealizeResult.Rejected;
@@ -61,7 +65,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 if (command.RouteNumber > 0 &&
                     pending.RouteNumber == command.RouteNumber)
                 {
-                    SyncInbox.RequestResync("pending route number conflict");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("pending route number conflict", "route",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("pending line number")
+                        .Tried("nothing - another line being created in this batch already claimed that number"));
                     Mod.log.Warn("[MP] RouteSync create: two different pending lines claim number " +
                                  command.RouteNumber + " for '" + command.PrefabName + "'.");
                     return RealizeResult.Rejected;
@@ -76,7 +84,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 command.Waypoints, out numberConflict);
             if (numberConflict)
             {
-                SyncInbox.RequestResync("route number conflict during creation");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route number conflict during creation", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("line number on creation")
+                    .Tried("nothing - an established line here already uses that number"));
                 Mod.log.Warn("[MP] RouteSync create: route number " + command.RouteNumber +
                              " for '" + command.PrefabName +
                              "' already belongs to a different line; requested a fresh world sync.");
@@ -90,7 +102,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 if (!TryApplyMetadata(existing, prefab, command.RouteNumber,
                         PackColor(command.ColorR, command.ColorG, command.ColorB, command.ColorA)))
                 {
-                    SyncInbox.RequestResync("route metadata conflict during idempotent creation");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("route metadata conflict during idempotent creation", "route",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("line metadata on re-creation")
+                        .Tried("nothing - the line already exists here with different metadata"));
                     return RealizeResult.Rejected;
                 }
                 MarkCreateGuards(command, now);
@@ -174,7 +190,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                         EntityManager.DestroyEntity(definition);
                     if (_netSync != null) _netSync.CancelPreparedDefinitionFrame();
                 }
-                SyncInbox.RequestResync("route creation failed");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route creation failed", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("line creation")
+                    .Tried("nothing - creation threw and was rolled back"));
                 Mod.log.Error("[MP] RouteSync create FAILED for '" +
                               command.PrefabName + "': " + ex);
                 return RealizeResult.Rejected;
@@ -186,7 +206,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             Entity prefab;
             if (!_prefabIndex.TryResolve(command.PrefabName, out prefab))
             {
-                SyncInbox.RequestResync("unknown route prefab during update");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("unknown route prefab during update", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("route prefab on update")
+                    .Tried("nothing - this game does not have the transport line prefab the other player used"));
                 Mod.log.Warn("[MP] RouteSync update: unknown prefab '" +
                              command.PrefabName + "'; skipping.");
                 return RealizeResult.Rejected;
@@ -222,7 +246,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 command.ColorB, command.ColorA);
             if (!RouteNumberAvailable(route, prefab, command.RouteNumber))
             {
-                SyncInbox.RequestResync("route number conflict during update");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route number conflict during update", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("line number on update")
+                    .Tried("nothing - another line here already uses the number this update assigns"));
                 Mod.log.Warn("[MP] RouteSync update: requested number " +
                              command.RouteNumber + " is already in use for '" +
                              command.PrefabName + "'.");
@@ -289,7 +317,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 // is applied explicitly even when the waypoint graph is rebuilt in the same frame.
                 if (!TryApplyMetadata(route, prefab, command.RouteNumber, rgba))
                 {
-                    SyncInbox.RequestResync("route number conflict during update");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("route number conflict during update", "route",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("line number on update")
+                        .Tried("nothing - another line here already uses the number this update assigns"));
                     Mod.log.Warn("[MP] RouteSync update: requested number " +
                                  command.RouteNumber + " is already in use for '" +
                                  command.PrefabName + "'.");
@@ -339,7 +371,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     if (_netSync != null) _netSync.CancelPreparedDefinitionFrame();
                     TryApplyMetadata(route, prefab, local.RouteNumber, local.Rgba);
                 }
-                SyncInbox.RequestResync("route update failed");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route update failed", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("line update")
+                    .Tried("nothing - the update threw and was rolled back"));
                 Mod.log.Error("[MP] RouteSync update FAILED for '" +
                               command.PrefabName + "': " + ex);
                 return RealizeResult.Rejected;
@@ -351,7 +387,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             Entity prefab;
             if (!_prefabIndex.TryResolve(command.PrefabName, out prefab))
             {
-                SyncInbox.RequestResync("unknown route prefab during deletion");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("unknown route prefab during deletion", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("route prefab on deletion")
+                    .Tried("nothing - this game does not have the transport line prefab the other player used"));
                 Mod.log.Warn("[MP] RouteSync delete: unknown prefab '" +
                              command.PrefabName + "'; skipping.");
                 return RealizeResult.Rejected;
@@ -395,7 +435,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             if (waypoints == null || waypoints.Length < 2 ||
                 waypoints.Length > RouteCreateCommand.MaxWaypoints)
             {
-                SyncInbox.RequestResync("invalid route topology");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("invalid route topology", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                    .About("line topology")
+                    .Tried("nothing - the described line does not form a valid route here"));
                 return false;
             }
 
@@ -404,7 +448,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 if (!string.IsNullOrEmpty(waypoints[i].StopPrefabName))
                     return true;
 
-            SyncInbox.RequestResync("public transport route without any stop rejected");
+            SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                .Create("public transport route without any stop rejected", "route",
+                    CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                .About("line with no stops")
+                .Tried("nothing - a public transport line with no stops cannot be created"));
             Mod.log.Warn("[MP] RouteSync rejected public-transport line '" + prefabName +
                          "' because none of its waypoints is connected to a stop.");
             return false;
@@ -882,7 +930,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 if (!TryApplyMetadata(route, pending.Prefab,
                         pending.RouteNumber, pending.Rgba, readyRoutes))
                 {
-                    SyncInbox.RequestResync("route number conflict after creation");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("route number conflict after creation", "route",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                        .About("line number after creation")
+                        .Tried("assigned every line finalized in this batch together before rejecting the conflict"));
                     Mod.log.Warn("[MP] RouteSync could not assign number " +
                                  pending.RouteNumber + " to '" + pending.PrefabName +
                                  "'; requested a fresh world sync.");
@@ -1000,12 +1052,25 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         {
             MultiplayerService service = Mod.Service;
             long now = service != null ? service.NowMs : 0;
-            if (service == null || !service.GameplaySyncReady ||
-                now >= command.DeadlineMs ||
+            // Gameplay not being ready means the world is already being replaced. The replacement
+            // supersedes this commit, so asking for another one is noise - and asking for a world
+            // reload BECAUSE a world reload is under way is how a session gets into a loop.
+            if (service == null || !service.GameplaySyncReady)
+            {
+                Mod.log.Warn("[MP] RouteSync " + operation +
+                             " commit was lost while the world was being replaced; the incoming " +
+                             "world supersedes it.");
+                return;
+            }
+            if (now >= command.DeadlineMs ||
                 _pendingCommands.Count >= MaxPendingCommands)
             {
-                SyncInbox.RequestResync("route " + operation +
-                                         " commit could not be replayed");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route commit could not be replayed", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                    .About("route " + operation + " commit")
+                    .Tried("nothing - the armed commit was wiped and its window had already closed")
+                    .Fact("route commands still queued", _pendingCommands.Count));
                 Mod.log.Warn("[MP] RouteSync " + operation +
                              " commit was lost and could not be replayed safely.");
                 return;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/Realize.cs
@@ -910,9 +910,17 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 
                 if (now < pending.DeadlineMs) continue;
                 _pendingCreateMetadata.RemoveAt(i);
-                SyncInbox.RequestResync(ambiguous
-                    ? "ambiguous created route"
-                    : "created route did not materialize");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create(ambiguous ? "ambiguous created route" : "created route did not materialize",
+                        "route", ambiguous
+                            ? CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction
+                            : CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                    .About("created line " + pending.PrefabName + " number " + pending.RouteNumber)
+                    .Tried(ambiguous
+                        ? "declined to guess between two equally good candidate lines"
+                        : "waited for the line the game builds from this definition, not counting " +
+                          "time route realization was held back")
+                    .Fact("line number", pending.RouteNumber));
                 Mod.log.Warn("[MP] RouteSync could not finalize created line '" +
                              pending.PrefabName + "' number " + pending.RouteNumber +
                              "; requested a fresh world sync.");

--- a/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/RouteSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/RouteSyncSystem.cs
@@ -236,10 +236,28 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         {
             MultiplayerService service = Mod.Service;
             if (service == null) return;
-            if (!service.GameplaySyncReady) return;
+            if (!service.GameplaySyncReady) { ExtendCreateMetadataWindows(service.NowMs); return; }
+
+            // This pass is not gated, but what it waits for is a route the game builds from a
+            // definition that RealizePending submits - and RealizePending IS gated. Counting the
+            // window down through that hold expires it against a line that could not yet exist,
+            // and the expiry asks for a world reload.
+            ExtendCreateMetadataWindows(service.NowMs);
 
             _mutatedRoutesThisFrame.Clear();
             FinalizeCreatedRoutes(service.NowMs);
+        }
+
+        private readonly Infrastructure.HeldTime _createMetadataHold = new Infrastructure.HeldTime();
+
+        private void ExtendCreateMetadataWindows(long nowMs)
+        {
+            long heldMs = _createMetadataHold.Observe(nowMs,
+                Infrastructure.RealizeGate.WorldBuildingHeld ||
+                _netSync == null || !_netSync.CanBuildDefinitions);
+            if (heldMs <= 0) return;
+            for (int i = 0; i < _pendingCreateMetadata.Count; i++)
+                _pendingCreateMetadata[i].DeadlineMs += heldMs;
         }
 
         /// <summary>Called by <see cref="SyncRealizeSystem"/> during ToolUpdate.</summary>
@@ -350,7 +368,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 }
                 catch (System.Exception ex)
                 {
-                    SyncInbox.RequestResync("malformed route command rejected");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("malformed route command rejected", "route",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                        .About("malformed route command")
+                        .Tried("nothing - the command could not be decoded"));
                     Mod.log.Warn("[MP] RouteSync: dropping malformed command: " + ex.Message);
                 }
             }
@@ -397,7 +419,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             }
 
             _pendingCommands.Clear();
-            SyncInbox.RequestResync("route retry queue overflow");
+            SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                .Create("route retry queue overflow", "route",
+                    CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                .About("route retry queue")
+                .Tried("nothing - the retry queue was full and was cleared"));
             Mod.log.Warn("[MP] RouteSync retry queue overflowed; cleared it and requested a fresh world sync.");
         }
 
@@ -413,7 +439,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             bool needsRecovery = pending.Delete == null ||
                                  DeleteStillNeedsRecovery(pending.Delete);
             if (needsRecovery)
-                SyncInbox.RequestResync("route " + operation + " dependency did not resolve");
+                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                    .Create("route " + operation + " dependency did not resolve", "route",
+                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                    .About("route dependency")
+                    .Tried("retried with backoff for 30 s of attempts, not counting time this system was held back"));
             Mod.log.Warn("[MP] RouteSync " + operation + " for '" + prefabName +
                          "' did not resolve within " + (RetryWindowMs / 1000) + " s" +
                          (pending.LastFailure != null ? " (" + pending.LastFailure + ")" : string.Empty) +

--- a/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/RouteSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Routes/RouteSyncSystem/RouteSyncSystem.cs
@@ -243,16 +243,51 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         }
 
         /// <summary>Called by <see cref="SyncRealizeSystem"/> during ToolUpdate.</summary>
+        /// <summary>
+        /// Called by <see cref="SyncRealizeSystem"/> on frames this system is not allowed to run -
+        /// terrain is catching up, or the net pipeline still has placements queued.
+        ///
+        /// A route's retry window is for waiting on its own stop, line or road to arrive, not for
+        /// waiting on permission to look. Measured against the wall it expired while this system
+        /// was gated off, and the expiry then reported a dependency that "did not resolve" and
+        /// asked for a world reload - for a command it had never once attempted. A stalled net
+        /// placement holds this gate for its whole retry window, so that was not a rare race.
+        /// </summary>
+        public void NotifyRealizeHeld(long nowMs)
+        {
+            ExtendPendingRouteWindows(nowMs);
+        }
+
+        /// <summary>When this system last got to attempt its pending commands.</summary>
+        private long _lastRouteRealizeMs;
+
+        private void ExtendPendingRouteWindows(long nowMs)
+        {
+            long heldMs = _lastRouteRealizeMs == 0 ? 0 : nowMs - _lastRouteRealizeMs;
+            _lastRouteRealizeMs = nowMs;
+            if (heldMs <= 0) return;
+            for (int i = 0; i < _pendingCommands.Count; i++)
+            {
+                _pendingCommands[i].DeadlineMs += heldMs;
+                _pendingCommands[i].NextAttemptMs += heldMs;
+            }
+        }
+
         public void RealizePending()
         {
             MultiplayerService service = Mod.Service;
             if (service == null) return;
 
             MultiplayerSession session = service.Session;
-            if (!service.GameplaySyncReady) return;
+            if (!service.GameplaySyncReady) { ExtendPendingRouteWindows(service.NowMs); return; }
 
             long now = service.NowMs;
-            if (_netSync == null || !_netSync.CanBuildDefinitions) return;
+            if (_netSync == null || !_netSync.CanBuildDefinitions)
+            {
+                ExtendPendingRouteWindows(now);
+                return;
+            }
+            _lastRouteRealizeMs = now;
 
             int budget = MaxCommandsPerFrame;
             int retries = System.Math.Min(_pendingCommands.Count, MaxCommandsPerFrame / 2);
@@ -390,6 +425,7 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         private void DrainQueue()
         {
             SyncInbox.Clear(_incoming);
+            _lastRouteRealizeMs = 0;
             _pendingCommands.Clear();
             _pendingCreateMetadata.Clear();
             _pendingUpdateCommit = null;

--- a/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/GrowableSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/GrowableSyncSystem.cs
@@ -87,6 +87,12 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         /// Positions this client has asked the build pipeline for, so the building that appears
         /// there is recognised as the host's rather than as one this machine grew.
         /// </summary>
+        /// <summary>
+        /// Set by <see cref="SyncRealizeSystem"/> while the net pipeline cannot deliver roads. A
+        /// growable waiting to join its road graph is waiting on exactly that pipeline.
+        /// </summary>
+        public bool NetworkDependenciesHeld;
+
         private sealed class PendingRealizedSpawn
         {
             public Entity Prefab;
@@ -279,6 +285,9 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             _playerPlacedGrowables.Clear();
             _stalePlayerPlacedGrowables.Clear();
             _lastPlayerPlacedPruneMs = 0;
+            _lastGrowableRealizeMs = 0;
+            _lastValidationTickMs = 0;
+            NetworkDependenciesHeld = false;
             // A replaced world arrives complete. Anything still queued for the old one refers to
             // buildings that no longer exist, and every sequence number belongs to a city that is
             // gone: keeping either would apply a stale decision to a fresh world.

--- a/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/Realize.cs
@@ -336,7 +336,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     if (_pendingStateCorrections.Count >= MaxPendingStateCorrections)
                     {
                         _pendingStateSequences.Remove(command.Sequence);
-                        SyncInbox.RequestResync("growable state retry queue overflow");
+                        SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                            .Create("growable state retry queue overflow", "growable",
+                                CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                            .About("state retry queue")
+                            .Tried("nothing - the pending-correction queue was full"));
                     }
                     else
                     {
@@ -372,7 +376,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                     _pendingStateCorrections.RemoveAt(i);
                     _unmatched++;
                     _applied.Remember(pending.Command.Sequence, now, ReplayWindowMs);
-                    SyncInbox.RequestResync("growable state target did not resolve");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("growable state target did not resolve", "growable",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                        .About("state correction target")
+                        .Tried("retried for 15 s of attempts, not counting time this system was held back"));
                     continue;
                 }
 
@@ -708,7 +716,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                         EntityManager.AddComponent<Updated>(entity);
                         if (_realizationValidations.Count >= MaxRealizationValidations)
                         {
-                            SyncInbox.RequestResync("growable realization validation overflow");
+                            SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                                .Create("growable realization validation overflow", "growable",
+                                    CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                                .About("realization validation queue")
+                                .Tried("nothing - the validation queue was full"));
                         }
                         else _realizationValidations.Add(new RealizationValidation
                         {
@@ -789,7 +801,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                  Format(pending.Position) + " did not join its road/service graph; " +
                                  "requesting world repair.");
                     Diagnostics.FlightRecorder.Note("growable realization invalid/resync");
-                    SyncInbox.RequestResync("growable building failed road/service realization");
+                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                        .Create("growable building failed road/service realization", "growable",
+                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.MissingTarget)
+                        .About("building road/service graph")
+                        .Tried("re-ran native initialization for 15 s of attempts, not counting time roads were held back"));
                     continue;
                 }
 

--- a/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/Simulation/GrowableSyncSystem/Realize.cs
@@ -33,10 +33,37 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         /// Applies the host's zoned-building decisions. Called from <see cref="SyncRealizeSystem"/>
         /// during ToolUpdate, the only phase in which a creation definition becomes a building.
         /// </summary>
+        /// <summary>
+        /// Called by <see cref="SyncRealizeSystem"/> on frames this system is not allowed to run -
+        /// terrain is catching up, or the net pipeline still has placements queued.
+        ///
+        /// A pending state correction's window is for waiting on its building to be generated, not
+        /// for waiting on permission to look for it. Against the wall it expired while this system
+        /// was gated off, and expiring asks for a world reload over a correction that was never
+        /// once attempted. A stalled net placement holds this gate for its whole retry window.
+        /// </summary>
+        public void NotifyRealizeHeld(long nowMs)
+        {
+            ExtendPendingStateWindows(nowMs);
+        }
+
+        /// <summary>When this system last got to attempt its pending corrections.</summary>
+        private long _lastGrowableRealizeMs;
+
+        private void ExtendPendingStateWindows(long nowMs)
+        {
+            long heldMs = _lastGrowableRealizeMs == 0 ? 0 : nowMs - _lastGrowableRealizeMs;
+            _lastGrowableRealizeMs = nowMs;
+            if (heldMs <= 0) return;
+            for (int i = 0; i < _pendingStateCorrections.Count; i++)
+                _pendingStateCorrections[i].Expiry += heldMs;
+        }
+
         public void RealizePending()
         {
             MultiplayerService service = Mod.Service;
-            if (service == null || !service.GameplaySyncReady) return;
+            if (service == null) return;
+            if (!service.GameplaySyncReady) { ExtendPendingStateWindows(service.NowMs); return; }
 
             MultiplayerSession session = service.Session;
             long now = service.NowMs;
@@ -51,7 +78,8 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
 
             // A zoned building's transmitted height was sampled on the sender's terrain. Realizing
             // it while remote terraforming is still backlogged buries or floats it.
-            if (DeferForTerrain) return;
+            if (DeferForTerrain) { ExtendPendingStateWindows(now); return; }
+            _lastGrowableRealizeMs = now;
 
             _applied.Prune(now);
             RetryPendingStateCorrections(now);
@@ -712,8 +740,28 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
         /// reciprocal road buffer, and the standard utility consumers. Persistent failure is
         /// structural divergence and escalates to the existing world-repair path.
         /// </summary>
+        /// <summary>When this pass last ran with the road pipeline able to deliver.</summary>
+        private long _lastValidationTickMs;
+
+        /// <summary>
+        /// A building is being validated for having joined its ROAD graph, and roads arrive through
+        /// the net pipeline. While that pipeline is held - terrain catching up, or a placement
+        /// waiting for a target - the road this building needs cannot arrive by definition, so the
+        /// window must not count down. It is the same fifteen seconds as the hold itself, so left
+        /// running it would ask for a world reload over a road the mod was still holding back.
+        /// </summary>
+        private void ExtendValidationWindowsWhileRoadsHeld(long now)
+        {
+            long heldMs = _lastValidationTickMs == 0 ? 0 : now - _lastValidationTickMs;
+            _lastValidationTickMs = now;
+            if (!NetworkDependenciesHeld || heldMs <= 0) return;
+            for (int i = 0; i < _realizationValidations.Count; i++)
+                _realizationValidations[i].Expiry += heldMs;
+        }
+
         private void ValidateRealizedBuildings(long now)
         {
+            ExtendValidationWindowsWhileRoadsHeld(now);
             for (int i = _realizationValidations.Count - 1; i >= 0; i--)
             {
                 RealizationValidation pending = _realizationValidations[i];

--- a/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/DeleteSyncSystem.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/DeleteSyncSystem.cs
@@ -26,6 +26,14 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
     public partial class DeleteSyncSystem : GameSystemBase
     {
         public bool DeferNetForTerrain;
+
+        /// <summary>
+        /// Set by <see cref="SyncRealizeSystem"/> while a remote placement is still waiting for the
+        /// road it anchors to. A bulldoze can only ever take that road away, and applying one here
+        /// inverts the order the two edits were made in - which is how a placement came to be
+        /// rejected for a "missing" target this system had removed a moment earlier.
+        /// </summary>
+        public bool DeferNetForPendingPlacement;
         private readonly ConcurrentQueue<SimulationCommandMessage> _incoming =
             new ConcurrentQueue<SimulationCommandMessage>();
         private readonly ReplicationGuard _guard = new ReplicationGuard();
@@ -237,13 +245,29 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             base.OnDestroy();
         }
 
+        /// <summary>When this system last got to run its match pass. See ExtendPendingDeleteWindows.</summary>
+        private long _lastDeleteRealizeMs;
+
+        private void ExtendPendingDeleteWindows(long now)
+        {
+            long frozenMs = _lastDeleteRealizeMs == 0 ? 0 : now - _lastDeleteRealizeMs;
+            _lastDeleteRealizeMs = now;
+            if (frozenMs <= 0) return;
+            for (int i = 0; i < _objectRetry.Count; i++)
+                _objectRetry[i] = (_objectRetry[i].cmd, _objectRetry[i].deadline + frozenMs);
+            for (int i = 0; i < _edgeRetry.Count; i++)
+                _edgeRetry[i] = (_edgeRetry[i].cmd, _edgeRetry[i].deadline + frozenMs);
+        }
+
         private void DrainQueue()
         {
             SyncInbox.Clear(_incoming);
+            _lastDeleteRealizeMs = 0;
             _replayEdgeDeletes.Clear();
             _objectRetry.Clear();
             _edgeRetry.Clear();
             DeferNetForTerrain = false;
+            DeferNetForPendingPlacement = false;
         }
 
         protected override void OnUpdate()
@@ -285,11 +309,21 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
             // applies) we leave incoming edge deletes queued and retry next cycle. A selected build
             // tool only blocks on its actual Apply/Clear frame. Object deletes (a raw Deleted tag on
             // a real entity) always proceed.
-            bool netBusy = DeferNetForTerrain || _netSync == null || !_netSync.CanBuildDefinitions;
+            bool netBusy = DeferNetForTerrain || DeferNetForPendingPlacement ||
+                           _netSync == null || !_netSync.CanBuildDefinitions;
             // Object deletion also tears down SubObject/SubNet/SubArea ownership. Keep it behind the
             // same graph lock as network work so it cannot invalidate an original while an isolated
             // building/connector transaction is being generated, applied, or drained.
-            if (netBusy) return;
+            if (netBusy)
+            {
+                // Time spent locked out is not the delete's fault. A pending delete's window is for
+                // waiting on its own build to arrive; letting it burn down while this system is not
+                // even allowed to look would drop a bulldoze that would have matched, and a dropped
+                // bulldoze is exactly the divergence that ends in a world reload later.
+                ExtendPendingDeleteWindows(service.NowMs);
+                return;
+            }
+            _lastDeleteRealizeMs = service.NowMs;
             long now = service.NowMs;
             long freshDeadline = now + DeleteRetryWindowMs;
             List<(ObjectDeleteCommand cmd, long deadline)> objects = null;

--- a/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/Realize.cs
@@ -94,7 +94,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                                 if (_objectRetry.Count >= MaxPendingDeletes)
                                 {
                                     _objectRetry.Clear();
-                                    SyncInbox.RequestResync("object delete retry queue overflow");
+                                    SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                                        .Create("object delete retry queue overflow", "delete",
+                                            CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.StreamLoss)
+                                        .About("object delete retry queue")
+                                        .Tried("nothing - the queue was full and was cleared"));
                                 }
                                 else _objectRetry.Add(commands[t]);
                                 waiting++;
@@ -102,7 +106,11 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                             else
                             {
                                 expired++;
-                                SyncInbox.RequestResync("object delete graph validation failed");
+                                SyncInbox.RequestResync(CS2MultiplayerMod.Game.Diagnostics.ResyncReport
+                                    .Create("object delete graph validation failed", "delete",
+                                        CS2MultiplayerMod.Game.Diagnostics.ResyncEvidence.Contradiction)
+                                    .About("object delete graph")
+                                    .Tried("nothing - the ownership graph under this object cannot be torn down safely"));
                                 Mod.log.Warn("[MP] DeleteSync: rejected stale building graph: " +
                                              invalidReason + ".");
                             }

--- a/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/Realize.cs
+++ b/CS2MultiplayerMod/Game/Sync/Systems/World/DeleteSyncSystem/Realize.cs
@@ -161,6 +161,13 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                 Mod.Verbose("[MP] DeleteSync: removed " + deleted + " object root(s) and " +
                              deletedOwned + " owned upgrade/subobject(s); " + waiting +
                              " awaiting a local match, " + expired + " gave up (already gone, or geometry diverged).");
+            // Same reasoning as the road case: a demolition that found nothing to demolish leaves
+            // this city holding a building the other player has already removed.
+            if (expired > 0)
+                Diagnostics.SyncLog.ProdWarn(
+                    "Build sync: " + expired + " demolished object(s) had no match here and were " +
+                    "dropped after " + (DeleteRetryWindowMs / 1000) + " s. Those objects still " +
+                    "stand in this city and no longer stand in the other player's.");
         }
 
         private bool TryCollectObjectDeleteGraph(Entity root, out List<Entity> ownedObjects,
@@ -375,6 +382,16 @@ namespace CS2MultiplayerMod.Game.Sync.Systems
                              " awaiting a local match, " + expired +
                              " gave up (already gone, or geometry diverged).");
             }
+            // A bulldoze that never found its road is a road the other player no longer has and
+            // this one still does - a silent divergence, and one that surfaces later as somebody
+            // else's edit failing to resolve. It was only ever visible with verbose logging on,
+            // which is exactly the switch nobody has set during the session that needs explaining.
+            // Production level, always.
+            if (expired > 0)
+                Diagnostics.SyncLog.ProdWarn(
+                    "Road sync: " + expired + " bulldozed road segment(s) had no match here and " +
+                    "were dropped after " + (DeleteRetryWindowMs / 1000) + " s. Those roads still " +
+                    "stand in this city and no longer stand in the other player's.");
         }
 
         /// <summary>

--- a/CS2MultiplayerMod/Mod.cs
+++ b/CS2MultiplayerMod/Mod.cs
@@ -106,6 +106,11 @@ namespace CS2MultiplayerMod
             Setting.ApplyPlatformNamePreset();
 
             Service = new MultiplayerService(coreLog);
+
+            // The sync pipeline asks before it reloads a world. Route that question at the live
+            // service, which owns the clock, the in-flight-recovery state and the arbiter.
+            Game.Sync.Infrastructure.SyncInbox.Arbitrate = Service.SettleResyncReport;
+
             FlightRecorder.Note("startup-stage service-created");
             log.Info("Multiplayer core initialised. Protocol v" +
                      CS2MultiplayerMod.Core.Protocol.ProtocolConstants.ProtocolVersion +
@@ -277,6 +282,9 @@ namespace CS2MultiplayerMod
         public void OnDispose()
         {
             log.Info(nameof(OnDispose));
+
+            Game.Sync.Infrastructure.SyncInbox.Arbitrate = null;
+            ResyncArbiter.Reset();
 
             if (Service != null)
             {

--- a/help/changelog.md
+++ b/help/changelog.md
@@ -24,6 +24,16 @@ Fewer world reloads, and a log that says why the ones that remain happened.
 - A bulldoze that never found anything to remove is now reported. It leaves a road or building
   standing here that the other player no longer has, and it used to be visible only with
   verbose logging switched on.
+- Terraforming now lands in one frame instead of being spread over several. Roads, buildings,
+  zoning, growables and routes all wait for terrain to catch up, so every extra frame spent
+  applying a stroke was a frame in which nothing else in the session could be applied either.
+- Terraforming that goes missing is now reported instead of being dropped in silence. A stroke
+  that could not be sent, or that arrived naming a tool this game does not have, leaves the
+  ground a different shape on the two machines - and the roads drawn near it afterwards then
+  fail to connect. Every one of those paths used to be invisible.
+- A terraforming sample that could not be applied no longer stops the whole session. It kept
+  the terrain queue permanently non-empty, and that queue is what every other kind of edit
+  waits behind, so one bad sample could leave a session unable to apply anything at all.
 
 ### Bug fixes
 

--- a/help/changelog.md
+++ b/help/changelog.md
@@ -4,6 +4,40 @@ title: Changelog
 
 # Changelog
 
+## Unreleased
+
+Fewer world reloads, and a log that says why the ones that remain happened.
+
+### Synchronization
+
+- A road placement waiting for the road it connects to no longer stops every other player's
+  edits behind it, and bulldozing no longer runs ahead of it. A bulldoze applied while a
+  placement waited could delete the very road that placement was anchored to, which then
+  looked like the two cities had diverged and triggered a full world reload.
+- Road endpoints can now be matched when the ground under them sits at a different height on
+  the two machines. Terrain and water routinely drift by more than the three metres the
+  matcher allowed, and past that point an ordinary road drawn near drifted ground could only
+  ever end in a world reload.
+- A large road edit is given time to finish in proportion to its size, and any progress
+  restarts its clock. A 311-piece replacement was being abandoned on the same three-second
+  budget that comfortably finished the 55-piece edits around it.
+- A bulldoze that never found anything to remove is now reported. It leaves a road or building
+  standing here that the other player no longer has, and it used to be visible only with
+  verbose logging switched on.
+
+### Bug fixes
+
+- Automatic world reloads now have to be justified before they happen. A reload costs both
+  players a save, a transfer and a load, and does not fix the edit that triggered it, so the
+  mod now writes down what it found, holds the mutating parts of the road pipeline still,
+  retries, and reloads only if the problem is still there. A problem that clears itself is
+  logged as a reload that did not have to happen.
+- The log now says why a world reload happened: which edit, which endpoint, what stands there
+  instead, how long the mod waited and what it tried first. Previously every cause printed one
+  short phrase and the world reloaded.
+- The host's log now records the reason a client asked to be re-synced, so a player pressing
+  the sync button reads differently from a client whose pipeline gave up on an edit.
+
 ## 0.1.6 - 2026-08-24
 
 This update focuses on synchronization, chat and general stability.

--- a/help/changelog.md
+++ b/help/changelog.md
@@ -34,6 +34,16 @@ Fewer world reloads, and a log that says why the ones that remain happened.
 - A terraforming sample that could not be applied no longer stops the whole session. It kept
   the terrain queue permanently non-empty, and that queue is what every other kind of edit
   waits behind, so one bad sample could leave a session unable to apply anything at all.
+- Transport lines and zoned buildings no longer give up on work they were never allowed to
+  attempt. Both wait a fixed time for something they depend on, and both are held back while
+  terrain or the road pipeline catches up - so the wait ran out against the clock rather than
+  against attempts, and asked for a world reload over a command that had never once been tried.
+- A zoned building waiting to join its road network no longer counts down that wait while the
+  road pipeline is the thing being held back.
+- Fixed a client that could sit waiting for a world forever. If the host finished a world
+  handover before this city had installed it, the client asked for a replacement - but its own
+  request was discarded as "a reload is already running", because the state it had just entered
+  looked like one. Nothing was coming, and only a manual sync recovered it.
 
 ### Bug fixes
 

--- a/help/changelog.md
+++ b/help/changelog.md
@@ -40,6 +40,17 @@ Fewer world reloads, and a log that says why the ones that remain happened.
   against attempts, and asked for a world reload over a command that had never once been tried.
 - A zoned building waiting to join its road network no longer counts down that wait while the
   road pipeline is the thing being held back.
+- Every remaining reason the mod can reload a world now records what it actually saw, instead
+  of a short phrase. A reason that says commands were lost, or that this city contradicts the
+  other player's, reloads at once; one that only says a deadline passed has to survive a hold
+  first, and a fault that clears during that hold is logged as a reload that did not happen.
+- Buildings, decorations, policies, appearance changes and transport lines no longer count down
+  their waiting time while the thing they are waiting for is being held back by the mod itself.
+  A prop waiting for its road, a policy waiting for its building and a line waiting to be
+  created could all run out of patience against the clock rather than against attempts.
+- A transport line whose commit was lost during a world reload no longer asks for another world
+  reload. The incoming world already replaces it, and asking again is how a session gets stuck
+  in a loop of them.
 - Fixed a client that could sit waiting for a world forever. If the host finished a world
   handover before this city had installed it, the client asked for a replacement - but its own
   request was discarded as "a reload is already running", because the state it had just entered


### PR DESCRIPTION
Investigation of three session logs, followed by an audit of every resync trigger in the mod.

The starting point was four automatic world reloads across two sessions. Three of the four turned out to be the mod's own doing rather than a divergence it observed, and the audit found the same pattern in a dozen more places.

## Why the reloads in the logs happened

**A deferred placement was parked in front of everything else.** A native placement waiting for the road it anchors to was re-queued at the *front* of the strictly ordered net queue, stopping every later operation from every player for the whole ten-second window.

**Bulldozing ran ahead of it.** Delete and replace live in their own feeders, so wire order between them and a waiting placement was never enforced. The flight log shows two bulldozes applied during the ten seconds one placement waited, after which the placement asked for a full reload because its target was "missing". Those feeders now stand down while a placement is stalled, and anything they were holding gets its retry window extended by the time it spent held.

**Road endpoints could not be matched across terrain drift.** The endpoint matcher allows three metres of vertical disagreement; the same logs show the mod correcting endpoint elevations by up to 3.5 m. Past that point an ordinary road drawn near drifted ground could only ever end in a reload. The existing local-surface projection (previously utility nets only) now covers roads and rails on the last-resort pass, with identity still matched strictly.

**The commit drain window was a fixed 3 s.** A 311-entity replacement was quarantined on the same budget that comfortably drained the 55- and 86-entity batches around it. It now scales with the batch and restarts whenever the batch makes progress.

## A resync now has to justify itself

Every automatic reload passes through a new arbiter. A claim about the **city** (a named thing is absent, an identity contradicts, commands were lost) settles on sight or on a second sighting. A claim about this machine's **pipeline** (a deadline, a budget, a drain window) is held first, with the mutating net feeders frozen so the retry sees a world that is standing still. A subsystem whose fault clears withdraws its report and no world is reloaded; one that never withdraws matures and reloads on schedule, so a real divergence is still repaired.

All 64 trigger sites now record what they saw instead of a bare phrase:

| Evidence | Count | Behaviour |
| --- | --- | --- |
| Contradiction | 25 | this city cannot represent the edit — reloads on sight |
| Stream loss | 25 | commands were shed or refused — reloads on sight |
| Missing target | 10 | something named is absent — reloads on a second sighting |
| Timeout | 4 | only a deadline passed — must survive a hold first |

## The pattern the audit found

A retry window measured against the wall clock while the system — or the thing it waits for — is gated off. The window then expires without the work ever having been attempted, and the expiry asks for a reload. BuildSync's attachment retry says it in its own comment: *"The parent road never reached us"* — and roads are exactly what the realize pipeline holds back.

Fixed in RouteSync (dependency windows and created-line metadata), GrowableSync (state corrections and road/service validation), BuildSync (attachment and blocked native object), PolicySync, VisualCustomizationSync, DeleteSync and NetReplaceSync. `RealizeGate` publishes the one fact none of them could see — whether roads, zoning and growables are currently held — and `HeldTime` turns it into milliseconds to add to a pending deadline.

Two further faults:

- **A client could wait for a world forever.** If the host resumed a handover before this client installed the snapshot, the client reset to `WaitingForMap` and asked for a replacement — but that request was discarded as "a reload is already running", because the state it had just entered looked like one. Nothing was coming; only a manual `/sync` recovered it.
- **A resync requested because a resync was running.** RouteSync treated a commit lost while gameplay was not ready as grounds to ask for recovery, but gameplay is not ready precisely because the world is already being replaced.

## Terrain

Terraforming is replayed as the sender's brush samples. Three problems:

- The per-frame apply budget was 64 samples, so a stroke took several frames to land — and `HasBacklog` holds back every road, building, zone, growable and route realize until terrain catches up. The game applies whatever brushes exist in one pass, so a bigger batch is one bigger frame rather than more frames. Raised to 512.
- Six paths dropped applied brush samples with no log at all, and capture returned outright on an implausible frame delta, discarding every sample in that frame. A terraforming sample is metres of height, so a dropped one leaves the ground a different shape on the two machines — and the roads drawn near it afterwards then fail to resolve. All are now counted and reported, split by side.
- A sample that threw during creation rejected its whole batch and left it queued, so it retried forever, so `HasBacklog` stayed true forever, and no road, building, zone, growable or route could be applied for the rest of the session. The failing sample is now skipped, and an apply that stays unavailable for 300 frames gives up with a report rather than wedging everything behind it.

## Logging

`SyncLog` gains a production level — always written, no prefix, mirrored to the flight recorder. Every outcome (held, withdrawn, settled) is written there as a full report: which edit, which endpoint, what actually stands there instead, how long it waited and what it tried first. Dropped bulldozes and dropped terraforming are reported there too; both were previously visible only with verbose logging on.

`ResyncRequest` carries its reason over the wire (**protocol v50**), so the host's log distinguishes a player pressing the sync button from a client whose pipeline gave up on an edit. The host log previously read `X requested a world sync` for both.

## Testing

**None of this has been compiled or run.** There was no .NET SDK or game assembly available while the work was done, so it has been verified by review and static checking only. Worth exercising before merge:

- The terrain batch size of 512 is the one tuned number here — watch for a hitch on large terraforms.
- `MissingTarget` triggers settle on a second sighting rather than waiting out the hold, so a genuinely missing route stop now repairs in about 15 s instead of 30.
- Protocol v50 means both players need this build.
